### PR TITLE
build 5384

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,28 @@
 # Harachain Smart Contracts Change Log
 
+# 2019-08-18
+## New Contract
+- ens/ENS: Ethereum name services abstraction.
+- ens/HNS: Hara Name Services Registry contract.
+- ens/HaraRegistrar: Registrar to regist new node by staking with hart.
+- ens/OwnerRegistrar: Registrar to regist new node by owner only.
+- ens/HaraResolver: Contract to keep all resolvers of nodes.
+- DataFactoryProvider: Contract to add data store relation version and it's value.
+- DataProviderNull: Data provider that return null URI.
+- DataProviderProxy: A proxy contract for curren tactive data provider.
+- DataProviderRelation: Data provider that keep relation of data store.
+
+## Contract Changes
+- [IDataProvider ] Changes `_priceId` parameter to `version`.
+- [Attest Contract] Implement EIP-780.
+- [Data Store] Changes `signature` storage from `bytes` to `mapping(bytes32=>bytes)`.
+- [Data Store] Add `editor` to allow DataFactoryProvider add new version.
+
+
+# 2019-07-02
+## New Contract
+- Data Provider Null Contract: A data provider contract that only return empty endpoint.
+- Data Provider Proxy: A proxy for calling other Data Provider Contract.
+- Data Provider Abstract: Abstract contract that can be use woth other data provider contract.
+## Contract Changes
+- [Data Provider Hara] Implement Data Provider Abstract

--- a/contracts/AdvancedPrice.sol
+++ b/contracts/AdvancedPrice.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity 0.5.2;
 
 import "./interfaces/IPriceable.sol";
 import "./../open-zeppelin/ownership/Ownable.sol";

--- a/contracts/AttestContract.sol
+++ b/contracts/AttestContract.sol
@@ -11,11 +11,13 @@ contract AttestContract is Ownable{
     
     mapping(bytes32=>Attribute) attestation;
     
-    event AttestActionLog(bytes32 encryptedBytes, bytes32 version, address itemAddress, bytes32 topic, address proxyAddress, bytes32 value, uint expiredTime);
+    event AttestActionLog(bytes32 encryptedBytes, bytes32 version, address itemAddress, bytes32 topic, address attestor, bytes32 value, uint expiredTime);
     event AttestResultLog(bytes32 encryptedBytes, bytes32 prevValue, uint prevExpiredTime, bytes32 newValue, uint newExpiredTime);
-    event WhoAttestLog(bytes32 encryptedBytes, bytes32 version, address itemAddress, bytes32 topic, address indexed proxyAddress);
-    event AttestLog(bytes32 encryptedBytes, bytes32 indexed version, address indexed itemAddress, bytes32 indexed topic, address proxyAddress);
-
+    event WhoAttestLog(bytes32 encryptedBytes, bytes32 version, address itemAddress, bytes32 topic, address indexed attestor);
+    event AttestLog(bytes32 encryptedBytes, bytes32 indexed version, address indexed itemAddress, bytes32 indexed topic, address attestor, bytes32 value, uint expiredTime);
+    event ClaimSet(address indexed issuer, address indexed subject, bytes32 indexed key, bytes32 value, uint updatedAt);
+    event ClaimRemoved(address indexed issuer, address indexed subject, bytes32 indexed key, uint removedAt);
+    
     constructor() public{
         
     }
@@ -26,26 +28,25 @@ contract AttestContract is Ownable{
     /// @param topic The topic of attestation.
     /// @param value the value of the attestation.
     /// @param expiredTime When attestation is still valid.
-    /// @param proxyAddress msg.sender claims to be this proxy address
     /// @return Returns transaction receipt.
-    function attest(bytes32 version, address itemAddress, bytes32 topic , address proxyAddress, bytes32 value, uint expiredTime) public {
-        bytes32 encryptedBytes = keccak256(abi.encodePacked(version, itemAddress, topic, proxyAddress));
+    function attest(bytes32 version, address itemAddress, bytes32 topic , bytes32 value, uint expiredTime) public {
+        bytes32 encryptedBytes = keccak256(abi.encodePacked(version, itemAddress, topic, msg.sender));
         emit AttestResultLog(encryptedBytes, attestation[encryptedBytes].value, attestation[encryptedBytes].expiredTime, value, expiredTime);
         attestation[encryptedBytes].value = value;
         attestation[encryptedBytes].expiredTime = expiredTime;
-        emit AttestActionLog(encryptedBytes, version, itemAddress, topic, proxyAddress, value, expiredTime);
-        emit WhoAttestLog(encryptedBytes, version, itemAddress, topic, proxyAddress);
-        emit AttestLog(encryptedBytes, version, itemAddress, topic, proxyAddress);
+        emit AttestActionLog(encryptedBytes, version, itemAddress, topic, msg.sender, value, expiredTime);
+        emit WhoAttestLog(encryptedBytes, version, itemAddress, topic, msg.sender);
+        emit AttestLog(encryptedBytes, version, itemAddress, topic, msg.sender, value, expiredTime);
     }
     
     /// @dev Allows anyone to get expired time of the attestation
     /// @param version The version of the data.
     /// @param itemAddress The address that will be attested.
     /// @param topic The topic of attestation.
-    /// @param proxyAddress The address of the proxyAddress.
+    /// @param attestor The issuer of the attestation
     /// @return Returns expired time from the spesific attestation.
-    function getExpiredTime(bytes32 version, address itemAddress, bytes32 topic, address proxyAddress) public view returns(uint){
-        bytes32 encryptedBytes = keccak256(abi.encodePacked(version, itemAddress, topic, proxyAddress));
+    function getExpiredTime(bytes32 version, address itemAddress, bytes32 topic, address attestor) public view returns(uint){
+        bytes32 encryptedBytes = keccak256(abi.encodePacked(version, itemAddress, topic, attestor));
         return attestation[encryptedBytes].expiredTime;
     }
 
@@ -53,10 +54,52 @@ contract AttestContract is Ownable{
     /// @param version The version of the data.
     /// @param itemAddress The address that will be attested.
     /// @param topic The topic of attestation.
-    /// @param proxyAddress The address of the proxyAddress.
-    /// @return Returns expired time from the spesific attestation.
-    function getValue(bytes32 version, address itemAddress, bytes32 topic, address proxyAddress) public view returns(bytes32){
-        bytes32 encryptedBytes = keccak256(abi.encodePacked(version, itemAddress, topic, proxyAddress));
+    /// @param attestor The issuer of the attestation
+    /// @return Returns value from the spesific attestation.
+    function getValue(bytes32 version, address itemAddress, bytes32 topic, address attestor) public view returns(bytes32){
+        bytes32 encryptedBytes = keccak256(abi.encodePacked(version, itemAddress, topic, attestor));
         return attestation[encryptedBytes].value;
+    }
+    /*=======EIP-780=======*/
+    /// @dev Used by an issuer to set the claim value with the key about the subject.
+    /// @param subject The address that will be attested
+    /// @param key The topic of attestation
+    /// @param value The value of the attestation
+    function setClaim(address subject, bytes32 key, bytes32 value) public {
+        bytes32 version = 0x0;
+        bytes32 encryptedBytes = keccak256(abi.encodePacked(version, subject, key, msg.sender));
+        attestation[encryptedBytes].value = value;
+        attestation[encryptedBytes].expiredTime = 0;
+        emit ClaimSet(msg.sender, subject, key, value, now);
+    }
+
+    /// @dev Convenience function for an issuer to set a claim about themself.
+    /// @param key The topic of attestation
+    /// @param value The value of the attestation
+    function setSelfClaim(bytes32 key, bytes32 value) public {
+        setClaim(msg.sender, key, value);
+    }
+
+    /// @dev Used by anyone to get a specific claim.
+    /// @param issuer The version of the data.
+    /// @param subject The address that will be attested.
+    /// @param key The topic of attestation.
+    /// @return Returns value from the spesific attestation.
+    function getClaim(address issuer, address subject, bytes32 key) public view returns(bytes32) {
+        bytes32 version = 0x0;
+        bytes32 encryptedBytes = keccak256(abi.encodePacked(version, subject, key, issuer));
+        return attestation[encryptedBytes].value;
+    }
+
+    /// @dev Used by an issuer to remove a claim it has made.
+    /// @param issuer The version of the data.
+    /// @param subject The address that will be attested.
+    /// @param key The topic of attestation.
+    function removeClaim(address issuer, address subject, bytes32 key) public {
+        require(msg.sender == issuer);
+        bytes32 version = 0x0;
+        bytes32 encryptedBytes = keccak256(abi.encodePacked(version, subject, key, issuer));
+        delete attestation[encryptedBytes];
+        emit ClaimRemoved(msg.sender, subject, key, now);
     }
 }

--- a/contracts/DataFactory.sol
+++ b/contracts/DataFactory.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity 0.5.2;
 
 import "./../open-zeppelin/ownership/Ownable.sol";
 import "./interfaces/IDataFactory.sol";

--- a/contracts/DataFactoryProvider.sol
+++ b/contracts/DataFactoryProvider.sol
@@ -1,0 +1,124 @@
+pragma solidity 0.5.2;
+
+import "./../open-zeppelin/ownership/Ownable.sol";
+import "./DataStore.sol";
+import "./DataProviderAbstract.sol";
+
+
+/**
+ * @title DataFactoryProvider
+ * @dev contract that will create data contract.
+ */
+contract DataFactoryProvider is Ownable {
+    // storage
+    DataStore public dataStore;
+    DataProviderAbstract public dataProvider;
+    
+    // events
+    event DataStoreChangedLog(address indexed who, address indexed oldAddress, address indexed newAddress);
+    event DataProviderChangedLog(address indexed who, address indexed oldAddress, address indexed newAddress);
+    event AllowedAddressLog(address indexed who, bool indexed isAllowed, address indexed by);
+    event ProxyLog(bytes32 indexed functionHash, uint8 status);
+    event RelationCreatedLog(string indexed fromAddr, string fromVersion, string indexed toAddr, string toVersion);
+    event FromRelationLog(string indexed fromAddr, string indexed fromVersion, string toAddr, string toVersion);
+    event ToRelationLog(string fromAddr, string fromVersion, string indexed toAddr, string indexed toVersion);
+    
+    /**
+    * @dev Constructor keep contract owner.
+    */
+    constructor(DataStore _dataStore, DataProviderAbstract _dataProvider)
+    public {
+        setDataStore(_dataStore);
+        setDataProvider(_dataProvider);
+    }
+
+    /**
+    * @dev Function to set Data Store address to use.
+    * @param _dataStore The address to set.
+    */
+    function setDataStore(DataStore _dataStore) 
+    public 
+    onlyOwner
+    {
+        address oldDataStoreAddress = address(dataStore);
+        dataStore = DataStore(_dataStore);
+        emit DataStoreChangedLog(msg.sender, oldDataStoreAddress, address(_dataStore));
+    }
+
+    /**
+    * @dev Function to set Data Provider address to use.
+    * @param _dataProvider The address to set.
+    */
+    function setDataProvider(DataProviderAbstract _dataProvider) 
+    public 
+    onlyOwner
+    {
+        address oldDataProvider = address(dataProvider);
+        dataProvider = _dataProvider;
+        emit DataProviderChangedLog(msg.sender, oldDataProvider, address(dataProvider));
+    }
+
+    /**
+    * @dev Function to store value to data provider.
+    * @param _version Version of data.
+    * @param _signature Signature of data.
+    * @param _fromAddr Address to connect.
+    * @param _fromVersion Version of Address to connect.
+    * @param _toAddr Address to be connect.
+    * @param _toVersion Version of address to be connect.
+    */
+    function addNewVersion(
+        bytes32 _version,
+        bytes memory _signature,
+        string memory _fromAddr, 
+        string memory  _fromVersion,
+        string memory _toAddr,
+        string memory _toVersion)
+    public
+    onlyOwner
+    {  
+        bytes32 _from = keccak256(abi.encodePacked(_fromAddr, _fromVersion));
+        string memory _to = string(abi.encodePacked(_toAddr, _toVersion));
+        storeSignature(_version, _signature);
+        upload(_from,_to);
+        emit RelationCreatedLog(_fromAddr, _fromVersion, _toAddr, _toVersion);
+        emit FromRelationLog(_fromAddr, _fromVersion, _toAddr, _toVersion);
+        emit ToRelationLog(_fromAddr, _fromVersion, _toAddr, _toVersion);
+    }
+    
+    // Data Store Functions    
+    /**
+    * @dev Function to set signature of new version on data store contract.
+    * @param _version Version of Data.
+    * @param _signature Signature of data.
+    */
+    function storeSignature(
+        bytes32 _version,
+        bytes memory _signature)
+    internal
+    returns (bool status)
+    
+    {  
+        emit ProxyLog(keccak256("setSignature(bytes32,bytes)"),0);
+        dataStore.setSignature(_version, _signature);
+        emit ProxyLog(keccak256("setSignature(bytes32,bytes)"),1);
+        return true;
+    }
+    
+    // Data Provider Function
+    /**
+    * @dev Function to store value to data provider.
+    * @param _from Bytes32 of Address and Version to connect.
+    * @param _to Bytes32 of Address and Version to be connected.
+    */
+    function upload(
+        bytes32 _from, 
+        string memory _to)
+    internal
+    {  
+        emit ProxyLog(keccak256("setEndpoint(bytes32,string)"),0);
+        require(dataProvider.setEndpoint(_from, _to), "Set Data Provider Failed");
+        emit ProxyLog(keccak256("setEndpoint(bytes32,string)"),0);
+    }
+
+}

--- a/contracts/DataFactoryRegistry.sol
+++ b/contracts/DataFactoryRegistry.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity 0.5.2;
 
 import "./../open-zeppelin/ownership/Ownable.sol";
 import "./interfaces/IDataFactory.sol";
@@ -39,10 +39,10 @@ contract DataFactoryRegistry is Ownable {
     /**
     * @dev Constructor keep contract owner.
     */
-    constructor(address _dataFactoryAddress)
+    constructor(IDataFactory _dataFactoryAddress)
     public {
         haraAddress = msg.sender;
-        dataFactory = IDataFactory(_dataFactoryAddress);
+        dataFactory = _dataFactoryAddress;
         haraPercentage = 15;
         emit PercentageChanged(0, 0, haraPercentage);
         dataProviderPercentage = 5;

--- a/contracts/DataProviderAbstract.sol
+++ b/contracts/DataProviderAbstract.sol
@@ -1,0 +1,43 @@
+pragma solidity 0.5.2;
+
+import "./interfaces/IDataProvider.sol";
+import "./../open-zeppelin/ownership/Ownable.sol";
+
+
+/**
+ * @title DataProviderAbstract
+ * @dev Abstratc Data provider contract.
+ */
+contract DataProviderAbstract is IDataProvider, Ownable {
+    address private proxy;
+
+    // events
+    event EndpointChangedLog(string oldEndpoint, string newEndpoint, address indexed by);
+    event ProxyChangedLog(address by, address oldProxy, address newProxy);
+
+    // modifier
+    /**
+    * @dev Modifier to check if function called by owner or proxy.
+    */
+    modifier onlyOwnerOrProxy() {
+        require(msg.sender == owner() || msg.sender == proxy, "Can only accesed by owner or proxy.");
+        _;
+    }
+
+    /**
+    * @dev Function to get Uri item from location Id.
+    * @param _newEndpoint Endpoint to be stored on contract.
+    */
+    function setEndpoint(bytes32 _key, string memory _newEndpoint) public returns (bool);
+
+    /**
+    * @dev Function to set data provider contract.
+    * @param _newProxyAddress Address of proxy.
+    */
+    function setProxyAddress(address _newProxyAddress) public onlyOwner {   
+        address old = address(proxy);
+        proxy = _newProxyAddress;
+        emit ProxyChangedLog(msg.sender, old, address(proxy));
+    }
+
+}

--- a/contracts/DataProviderHara.sol
+++ b/contracts/DataProviderHara.sol
@@ -1,32 +1,23 @@
-pragma solidity ^0.5.2;
+pragma solidity 0.5.2;
 
-import "./interfaces/IDataProvider.sol";
-
+import "./DataProviderAbstract.sol";
 
 /**
  * @title DataProviderHara
  * @dev Data provider contract by hara.
  */
-contract DataProviderHara is IDataProvider {
-
-    address public owner;
-    string public endpoint;
+contract DataProviderHara is DataProviderAbstract {
+    string internal endpoint;
         
     // events
     event EndpointChangedLog(string oldEndpoint, string newEndpoint, address indexed by);
 
     // modifier
     /**
-    * @dev Modifier to check if function called by owner.
+    * @dev Modifier to check if endpoint is exists.
     */
-    modifier onlyOwner() {
-        require(msg.sender == owner, "Can only accesed by owner.");
-        _;
-    }
-
     modifier endpointExists() {
         require(bytes(endpoint).length > 0, "Endpoint is not exists");
-        // require(endpoint != "", "Endpoint is not exists");
         _;
     }
 
@@ -34,27 +25,27 @@ contract DataProviderHara is IDataProvider {
     * @dev Constructor.
     */
     constructor() public {
-        owner = msg.sender;
     }
 
     /**
     * @dev Function to get Uri item from location Id.
     * @param _locationId Location Id of item.
-    * @param _priceId Price Id as a versio of item.
-    * @param _buyer Address of buyer.
+    * @param _version Version of item.
     */
-    function getUri(string memory _locationId, string memory _priceId, string memory _buyer) public view 
+    function getUri(string memory _locationId, string memory _version) public view 
     endpointExists returns (string memory uri) {
-        return string(abi.encodePacked(endpoint, "?id=", _locationId, "&&version=", _priceId, "&&address=", _buyer));
+        return string(abi.encodePacked(endpoint, "?id=", _locationId, "&&version=", _version));
     }
 
     /**
     * @dev Function to get Uri item from location Id.
+    * @param _key Not in use.
     * @param _newEndpoint Endpoint to be stored on contract.
     */
-    function setEndpoint(string memory _newEndpoint) public onlyOwner {
+    function setEndpoint(bytes32 _key, string memory _newEndpoint) public onlyOwnerOrProxy returns (bool) {
         string memory _oldEndpoint = endpoint;
         endpoint = _newEndpoint;
         emit EndpointChangedLog(_oldEndpoint, endpoint, msg.sender);
+        return true;
     }
 }

--- a/contracts/DataProviderNull.sol
+++ b/contracts/DataProviderNull.sol
@@ -1,0 +1,23 @@
+pragma solidity 0.5.2;
+
+import "./interfaces/IDataProvider.sol";
+import "./../open-zeppelin/ownership/Ownable.sol";
+
+
+/**
+ * @title DataProviderNull
+ * @dev Data provider contract that provide null endpoint.
+ */
+contract DataProviderNull is IDataProvider, Ownable {
+    string internal endpoint;
+
+    /**
+    * @dev Function to get Uri item from location Id.
+    * @param _locationId Location Id of item. Not in used.
+    * @param _version Price Id as a version of item. Not in used.
+    */
+    function getUri(string memory _locationId, string memory _version) public view 
+    returns (string memory uri) {
+        return endpoint;
+    }
+}

--- a/contracts/DataProviderProxy.sol
+++ b/contracts/DataProviderProxy.sol
@@ -1,0 +1,63 @@
+pragma solidity 0.5.2;
+
+import "./../open-zeppelin/ownership/Ownable.sol";
+import "./DataProviderAbstract.sol";
+
+
+/**
+ * @title Data ProviderProxy
+ * @dev Contract that proxy data provider contract.
+ */
+contract DataProviderProxy is Ownable {
+    // storage
+    DataProviderAbstract public dataProvider;
+
+    // events
+    event DataProviderChangedLog(address indexed who, address indexed oldAddress, address indexed newAddress);
+    event ProxyLog(bytes32 indexed functionHash, uint8 status); // 0 before, 1 after
+    
+    /**
+    * @dev Constructor keep data provider.
+    */
+    constructor(DataProviderAbstract _dataProvider)
+    public {
+        setDataProvider(_dataProvider);
+    }
+
+    /**
+    * @dev Function to set data provider contract.
+    * @param _newDataProvider Address of data provider contract.
+    */
+    function setDataProvider(DataProviderAbstract _newDataProvider) public onlyOwner returns (string memory uri) 
+    {   
+        address old = address(dataProvider);
+        dataProvider = _newDataProvider;
+        emit DataProviderChangedLog(msg.sender, old, address(dataProvider));
+    }
+
+    /**
+    * @dev Function to set endpoint of data provider.
+    * @param _key .
+    * @param _newEndpoint New Endpoint for Data Provider.
+    */
+    function setEndpoint(bytes32 _key, string memory _newEndpoint)
+    public
+    onlyOwner
+    returns (bool)
+    {   
+        emit ProxyLog(keccak256("SetEndpoint(address"), 0);
+        dataProvider.setEndpoint(_key, _newEndpoint);
+        emit ProxyLog(keccak256("SetEndpoint(address"), 1);
+        return true;
+    }
+
+    /**
+    * @dev Function to get Uri address of data location.
+    * @param _locationId Location Id of item.
+    * @param _version Version of item.
+    */
+    function getUri(string calldata _locationId, string calldata _version)  external view returns (string memory uri) 
+    {
+        uri = dataProvider.getUri(_locationId, _version);
+    }
+}

--- a/contracts/DataProviderRegistry.sol
+++ b/contracts/DataProviderRegistry.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity 0.5.2;
 
 import "./interfaces/IDataProvider.sol";
 import "./interfaces/IPriceable.sol";

--- a/contracts/DataProviderRelation.sol
+++ b/contracts/DataProviderRelation.sol
@@ -1,0 +1,43 @@
+pragma solidity 0.5.2;
+
+import "./DataProviderAbstract.sol";
+
+/**
+ * @title DataProviderRelation
+ * @dev Data provider contract with value.
+ */
+contract DataProviderRelation is DataProviderAbstract {
+
+    mapping(bytes32=>string) internal endpoints;
+    // events
+    event EndpointChangedLog(string oldEndpoint, string newEndpoint, address indexed by);
+
+    /**
+    * @dev Constructor.
+    */
+    constructor() public {
+    }
+
+    /**
+    * @dev Function to get Uri item from location Id.
+    * @param _locationId Location Id of item.
+    * @param _version Version of item.
+    */
+    function getUri(string memory _locationId, string memory _version) public view 
+    returns (string memory uri) {
+        bytes32 key = keccak256(abi.encodePacked(_locationId, _version));
+        uri = endpoints[key];
+    }
+
+     /**
+    * @dev Function to get Uri item from location Id.
+    * @param _from Object as key.
+    * @param _to Endpoint to be stored on contract.
+    */
+    function setEndpoint(bytes32 _from, string memory _to) public onlyOwnerOrProxy returns (bool) {
+        string memory _oldEndpoint = endpoints[_from];
+        endpoints[_from] = _to;
+        emit EndpointChangedLog(_oldEndpoint, endpoints[_from], msg.sender);
+        return true;
+    }
+}

--- a/contracts/DexItem.sol
+++ b/contracts/DexItem.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity 0.5.2;
 
 import "./interfaces/IPriceable.sol";
 import "./interfaces/IBuyable.sol";

--- a/contracts/ExchangeHARTIDR.sol
+++ b/contracts/ExchangeHARTIDR.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity 0.5.2;
 
 import "./../open-zeppelin/ownership/Ownable.sol";
 import "./../open-zeppelin/math/SafeMath.sol";

--- a/contracts/ExchangeRate.sol
+++ b/contracts/ExchangeRate.sol
@@ -4,7 +4,11 @@ import "./../open-zeppelin/math/SafeMath.sol";
 import "./../open-zeppelin/ownership/Ownable.sol";
 import "./interfaces/IExchangeRate.sol";
 
-contract ExchangeRate is Ownable {
+interface SpecialPrice {
+    function getPrice(uint256 _basePrice) external view returns (uint256 finalPrice);
+}
+
+contract ExchangeRate is Ownable, SpecialPrice {
     using SafeMath for uint256;
     
     // storage

--- a/contracts/HaraTokenPrivate.sol
+++ b/contracts/HaraTokenPrivate.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity 0.5.2;
 
 /**
  * @title Roles
@@ -402,8 +402,6 @@ interface IBuyMechanism {
     returns (address buyer, address seller, bytes32 id, uint256 value);
 }
 
-pragma solidity ^0.5.2;
-
 
 /**
  * @title Buyable
@@ -422,8 +420,6 @@ interface IBuyable {
     // one txReceipt only for one transaction receipt
     function buy(uint256 _txReceipt) external returns (bool);
 }
-
-pragma solidity ^0.5.2;
 
 
 /**

--- a/contracts/Order.sol
+++ b/contracts/Order.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.2;
+pragma solidity 0.5.2;
 
 import "./../open-zeppelin/ownership/Ownable.sol";
 import "./../open-zeppelin/math/SafeMath.sol";

--- a/contracts/ens/HNS.sol
+++ b/contracts/ens/HNS.sol
@@ -11,12 +11,12 @@ contract HNSRegistry is ENS {
 
     struct Record {
         address owner;
-        address resolver;
         uint64 ttl;
     }
 
     mapping (bytes32 => Record) records;
     address public activeRegistrar;
+    address public activeResolver;
 
     // Permits modifications only by the owner of the specified node
     modifier ownerOnly(bytes32 _node) {
@@ -26,14 +26,9 @@ contract HNSRegistry is ENS {
 
     // Permits modifications only by the owner of the specified node if active registrar not specified.
     // only active registrar address if active registar specified.
-    modifier registrarOnly(bytes32 _node) {
-        if(activeRegistrar!=address(0)){
-            require(activeRegistrar == msg.sender, "Can only be accesed by registar");
-            _;
-        } else {
-            require(records[_node].owner == msg.sender, "Can only be accesed by owner");
-            _;
-        }
+    modifier registrarOnly() {
+        require(activeRegistrar == msg.sender, "Can only be accesed by registar");
+        _;
     }
 
     event RegistrarChanged(address oldRegistrar, address newRegistrar);
@@ -71,7 +66,7 @@ contract HNSRegistry is ENS {
      * @param _label The hash of the label specifying the subnode.
      * @param _owner The address of the new owner.
      */
-    function setSubnodeOwner(bytes32 _node, bytes32 _label, address _owner) external registrarOnly(_node) {
+    function setSubnodeOwner(bytes32 _node, bytes32 _label, address _owner) external registrarOnly() {
         bytes32 subnode = keccak256(abi.encodePacked(_node, _label));
         emit NewOwner(_node, _label, _owner);
         records[subnode].owner = _owner;
@@ -79,12 +74,12 @@ contract HNSRegistry is ENS {
 
     /**
      * @dev Sets the resolver address for the specified node.
-     * @param _node The node to update.
+     * @param _node The node to update. Not in use.
      * @param _resolver The address of the resolver.
      */
-    function setResolver(bytes32 _node, address _resolver) external ownerOnly(_node) {
-        emit NewResolver(_node, _resolver);   
-        records[_node].resolver = _resolver;
+    function setResolver(bytes32 _node, address _resolver) external ownerOnly(0x0) {
+        emit NewResolver("", _resolver);   
+        activeResolver = _resolver;
     }
 
     /**
@@ -108,11 +103,11 @@ contract HNSRegistry is ENS {
 
     /**
      * @dev Returns the address of the resolver for the specified node.
-     * @param _node The specified node.
+     * @param _node The specified node. Not in use.
      * @return address of the resolver.
      */
     function resolver(bytes32 _node) external view returns (address) {
-        return records[_node].resolver;
+        return activeResolver;
     }
 
     /**

--- a/contracts/ens/OwnerRegistrar.sol
+++ b/contracts/ens/OwnerRegistrar.sol
@@ -1,0 +1,34 @@
+pragma solidity 0.5.2;
+
+import "./ENS.sol";
+import "./../../open-zeppelin/ownership/Ownable.sol";
+
+/**
+ * A Registrar to register subdomain on HNS.
+ */
+contract OwnerRegistrar is Ownable {
+    ENS public ens;
+    
+    // Events
+    event SubnodeRegistered(bytes32 indexed node, bytes32 indexed label, address owner, uint256 price);
+
+    /**
+     * Constructor.
+     * @param _ensAddr The ENS registrar contract address.
+     */
+    constructor(ENS _ensAddr) public {
+        ens = _ensAddr;
+    }
+
+    /**
+    * @dev Function to request subnode registration.
+    * @param _node Parent node namehash.
+    * @param _label Label of subnode.
+    * @param _owner Owner adddres of subdnode.
+    * @return Boolean of buy status.
+    */
+    function register(bytes32 _node, bytes32 _label, address _owner) public onlyOwner {
+        ens.setSubnodeOwner(_node, _label, _owner);
+        emit SubnodeRegistered(_node, _label, _owner, 0);
+    }
+}

--- a/contracts/interfaces/ContractMadeAbstract.sol
+++ b/contracts/interfaces/ContractMadeAbstract.sol
@@ -1,0 +1,30 @@
+pragma solidity 0.5.2;
+
+
+/**
+ * @title ContractMadeAbstract
+ * @dev Interface for every contract with getClass function
+ */
+contract ContractMadeAbstract {
+    string internal class;
+
+    // events
+    event HasGetClass();
+    
+    constructor(string memory hns) public {
+        class = hns;
+        emit HasGetClass();
+    }
+
+        /**
+    * @dev Function to get class HNS.
+    * @return String of class HNS.
+    * 
+    */
+    function getClass() 
+    external
+    view 
+    returns(string memory hns) {
+        hns = class;
+    }
+}

--- a/contracts/interfaces/IAttest.sol
+++ b/contracts/interfaces/IAttest.sol
@@ -7,12 +7,12 @@ pragma solidity ^0.5.2;
 interface IAttest {
 
     // events
-    event AttestActionLog(bytes32 encryptedBytes, uint64 version, address dataStoreAddress, bytes32 topic, address proxyAddress, bytes32 value, uint expiredTime);
+    event AttestActionLog(bytes32 encryptedBytes, uint64 version, address dataStoreAddress, bytes32 topic, address attestor, bytes32 value, uint expiredTime);
     event AttestResultLog(bytes32 encryptedBytes, bytes32 prevValue, uint prevExpiredTime, bytes32 newValue, uint newExpiredTime);
-    event WhoAttestLog(bytes32 encryptedBytes, uint64 version, address dataStoreAddress, bytes32 topic, address indexed proxyAddress);
-    event AttestLog(bytes32 encryptedBytes, uint64 indexed version, address indexed dataStoreAddress, bytes32 indexed topic, address proxyAddress);
+    event WhoAttestLog(bytes32 encryptedBytes, uint64 version, address dataStoreAddress, bytes32 topic, address indexed attestor);
+    event AttestLog(bytes32 encryptedBytes, uint64 indexed version, address indexed dataStoreAddress, bytes32 indexed topic, address attestor);
     
-    function attest(uint64 version, address dataStoreAddress, bytes32 topic, bytes32 value, uint expired, address proxyAddress) external;
+    function attest(uint64 version, address dataStoreAddress, bytes32 topic, bytes32 value, uint expired, address attestor) external;
     function getExpired(uint64 version, address dataStoreAddress, bytes32 topic, address attestor) external view returns(uint);
     function getValue(uint64 version, address dataStoreAddress, bytes32 topic, address attestor) external view returns(bytes32);
     

--- a/contracts/interfaces/IDataProvider.sol
+++ b/contracts/interfaces/IDataProvider.sol
@@ -7,6 +7,6 @@ pragma solidity ^0.5.2;
  */
 contract IDataProvider {
 
-    function getUri(string calldata _locationId, string calldata _priceId, string calldata _buyer) external view returns (string memory uri);
+    function getUri(string calldata _locationId, string calldata _version) external view returns (string memory uri);
 
 }

--- a/contracts/multisignature/MultiSigHNS.sol
+++ b/contracts/multisignature/MultiSigHNS.sol
@@ -1,0 +1,121 @@
+pragma solidity 0.5.2;
+
+import './MultiSignature.sol';
+import './../ens/HNS.sol';
+
+contract MultiSigHNS is MultiSignature{
+
+    HNSRegistry hns;
+
+    constructor (HNSRegistry _ensAddress) public {
+        hns = _ensAddress;
+    }
+
+    /// @dev Executes multisig functions.
+    /// @param _transactionId Transaction ID.
+    /// @param _txType Type of transaction.
+    /// @param _data Data to execute.
+    /// @return Confirmation status.
+    function doExecute(uint _transactionId, uint256 _txType, bytes memory _data) public {
+        if (_txType == 3){ // setOwner
+            (bytes32 node, address owner) = abi.decode(_data, (bytes32, address));
+            hns.setOwner(node, owner);
+            emit Execution(_transactionId);
+        }
+        else if (_txType == 4) { // setSubOwner
+            (bytes32 node, bytes32 label, address owner) = abi.decode(_data, (bytes32, bytes32, address));
+            hns.setSubnodeOwner(node, label, owner);
+            emit Execution(_transactionId);
+        }
+        else if (_txType == 5) { // setResolver
+            (bytes32 node, address resolver) = abi.decode(_data, (bytes32, address));
+            hns.setResolver(node, resolver);
+            emit Execution(_transactionId);
+        }
+        else if (_txType == 6) { // setTTL
+            (bytes32 node, uint64 ttl) = abi.decode(_data, (bytes32, uint64));
+            hns.setTTL(node, ttl);
+            emit Execution(_transactionId);
+        }
+        else if (_txType == 7) { // setRegistrar
+            (address registraraddress) = abi.decode(_data, (address));
+            hns.setRegistrar(registraraddress);
+            emit Execution(_transactionId);
+        }
+        else {
+            Transaction storage txn = transactions[_transactionId];
+            txn.executed = false;
+            emit ExecutionFailure(_transactionId);
+        }
+    }
+
+    /// @dev Allows an owner to submit and confirm a hns set owner transaction.
+    /// @param node HNS Node.
+    /// @param owner Number of wei to withdraw.
+    /// @return Returns transaction ID.
+    function submitSetOwner(bytes32 node, address owner)
+        public
+        ownerExists(msg.sender)
+        returns (uint transactionId)
+    {
+        bytes memory data = abi.encode(node, owner);
+        transactionId = addTransaction(address(hns), data, 3);
+        confirmTransaction(transactionId);
+    }
+    
+    /// @dev Allows an owner to submit and confirm a hns set subnode owner transaction.
+    /// @param node HNS parent node.
+    /// @param label HNS sha3 label.
+    /// @param owner Owner of HNS.
+    /// @return Returns transaction ID.
+    function submitSetSubnodeOwner(bytes32 node, bytes32 label, address owner)
+        public
+        ownerExists(msg.sender)
+        returns (uint transactionId)
+    {
+        bytes memory data = abi.encode(node, label, owner);
+        transactionId = addTransaction(address(hns), data, 4);
+        confirmTransaction(transactionId);
+    }
+
+   /// @dev Allows an owner to submit and confirm a hns resolver transaction.
+    /// @param node HNS node.
+    /// @param resolver Resolver of HNS.
+    /// @return Returns transaction ID.
+    function submitSetResolver(bytes32 node, address resolver)
+        public
+        ownerExists(msg.sender)
+        returns (uint transactionId)
+    {
+        bytes memory data = abi.encode(node, resolver);
+        transactionId = addTransaction(address(hns), data, 5);
+        confirmTransaction(transactionId);
+    }
+
+    /// @dev Allows an owner to submit and confirm a hns set ttl transaction.
+    /// @param node HNS node.
+    /// @param ttl TTL of node.
+    /// @return Returns transaction ID.
+    function submitSetTTL(bytes32 node, uint64 ttl)
+        public
+        ownerExists(msg.sender)
+        returns (uint transactionId)
+    {
+        bytes memory data = abi.encode(node, ttl);
+        transactionId = addTransaction(address(hns), data, 6);
+        confirmTransaction(transactionId);
+    }
+
+    /// @dev Allows an owner to submit and confirm a hns set registrar transaction.
+    /// @param _registrar Registrar of HNS.
+    /// @return Returns transaction ID.
+    function submitSetRegistrar(address _registrar)
+        public
+        ownerExists(msg.sender)
+        returns (uint transactionId)
+    {
+        bytes memory data = abi.encode(_registrar);
+        transactionId = addTransaction(address(hns), data, 7);
+        confirmTransaction(transactionId);
+    }
+}

--- a/contracts/multisignature/MultiSignature.sol
+++ b/contracts/multisignature/MultiSignature.sol
@@ -1,0 +1,347 @@
+pragma solidity 0.5.2;
+
+/// @title Multisignature abstract contract.
+contract MultiSignature {
+
+    /*
+     *  Events
+     */
+    event Confirmation(address indexed sender, uint indexed transactionId);
+    event Revocation(address indexed sender, uint indexed transactionId);
+    event Submission(uint indexed transactionId);
+    event Execution(uint indexed transactionId);
+    event ExecutionFailure(uint indexed transactionId);
+    event OwnerAddition(address indexed owner);
+    event OwnerRemoval(address indexed owner);
+    event RequirementChange(uint required);
+
+    /*
+     *  views
+     */
+    uint public MAX_OWNER_COUNT = 50;
+
+    /*
+     *  Storage
+     */
+    mapping (uint => Transaction) public transactions;
+    mapping (uint => mapping (address => bool)) public confirmations;
+    mapping (address => bool) public isOwner;
+    address[] public owners;
+    uint public required;
+    uint public transactionCount;
+
+    struct Transaction {
+        address destination;
+        uint txType; // 1 = addOwner 2 = removeOwner , >3 = others
+        bytes data;
+        bool executed;
+    }
+
+    /*
+     *  Modifiers
+     */
+    modifier ownerDoesNotExist(address owner) {
+        require(!isOwner[owner]);
+        _;
+    }
+
+    modifier ownerExists(address owner) {
+        require(isOwner[owner]);
+        _;
+    }
+
+    modifier transactionExists(uint transactionId) {
+        require(transactions[transactionId].destination != address(0));
+        _;
+    }
+
+    modifier confirmed(uint transactionId, address owner) {
+        require(confirmations[transactionId][owner]);
+        _;
+    }
+
+    modifier notConfirmed(uint transactionId, address owner) {
+        require(!confirmations[transactionId][owner]);
+        _;
+    }
+
+    modifier notExecuted(uint transactionId) {
+        require(!transactions[transactionId].executed);
+        _;
+    }
+
+    modifier notNull(address _address) {
+        require(_address != address(0));
+        _;
+    }
+
+    modifier validRequirement(uint ownerCount, uint _required) {
+        require(ownerCount <= MAX_OWNER_COUNT
+            && _required <= ownerCount
+            && _required != 0
+            && ownerCount != 0);
+        _;
+    }
+
+    // Must be define on inherit Smart Contract
+    function doExecute(uint transactionId, uint256 txType, bytes memory data) public;
+
+    /*
+     * Public functions
+     */
+    /// @dev Contract constructor sets initial owners and required number of confirmations.
+    constructor()
+        public
+    {
+        owners = [msg.sender];
+        isOwner[msg.sender] = true;
+        required = 1;
+    }
+    
+    /// @dev Allows to add a new owner. Transaction has to be sent by owner.
+    /// @param owner Address of new owner.
+    function addOwner(address owner)
+        private
+        ownerExists(msg.sender)
+        ownerDoesNotExist(owner)
+        notNull(owner)
+        validRequirement(owners.length + 1, required)
+        returns (bool) 
+    {
+        isOwner[owner] = true;
+        owners.push(owner);
+        emit OwnerAddition(owner);
+        uint halfOwner = uint(owners.length)/2;
+        changeRequirement(halfOwner + 1);
+        return true;
+    }
+
+    /// @dev Allows to remove an owner. Transaction has to be sent by owner.
+    /// @param owner Address of owner.
+    function removeOwner(address owner)
+        private
+        ownerExists(owner)
+        ownerExists(msg.sender)
+        returns (bool) 
+    {
+        uint halfOwner = uint(owners.length - 1)/2;
+        changeRequirement(halfOwner + 1);
+
+        isOwner[owner] = false;
+        for (uint i=0; i<owners.length - 1; i++)
+            if (owners[i] == owner) {
+                owners[i] = owners[owners.length - 1];
+                break;
+            }
+        owners.length -= 1;
+        emit OwnerRemoval(owner);
+        return true;
+    }
+
+    /// @dev Allows to replace an owner with a new owner. Transaction has to be sent by owner.
+    /// @param owner Address of owner to be replaced.
+    /// @param newOwner Address of new owner.
+    function replaceOwner(address owner, address newOwner)
+        public
+        ownerExists(msg.sender)
+        ownerExists(owner)
+        ownerDoesNotExist(newOwner)
+    {
+        for (uint i=0; i<owners.length; i++)
+            if (owners[i] == owner) {
+                owners[i] = newOwner;
+                break;
+            }
+        isOwner[owner] = false;
+        isOwner[newOwner] = true;
+        emit OwnerRemoval(owner);
+        emit OwnerAddition(newOwner);
+    }
+
+    /// @dev Allows to change the number of required confirmations. Transaction has to be sent by owner.
+    /// @param _required Number of required confirmations.
+    function changeRequirement(uint _required)
+        private
+        ownerExists(msg.sender)
+        validRequirement(owners.length, _required)
+    {
+        required = _required;
+        emit RequirementChange(_required);
+    }
+
+    /// @dev Allows an owner to submit and confirm a withdraw token transaction.
+    /// @param owner new owner.
+    /// @return Returns transaction ID.
+    function submitAddOwnerTransaction(address owner)
+        public
+        ownerExists(msg.sender)
+        returns (uint transactionId)
+    {
+        transactionId = addTransaction(owner, "", 1);
+        confirmTransaction(transactionId);
+    }
+
+    /// @dev Allows an owner to submit and confirm a withdraw token transaction.
+    /// @param owner old owner.
+    /// @return Returns transaction ID.
+    function submitRemoveOwnerTransaction(address owner)
+        public
+        ownerExists(msg.sender)
+        returns (uint transactionId)
+    {
+        transactionId = addTransaction(owner, "", 2);
+        confirmTransaction(transactionId);
+    }
+
+    /// @dev Allows an owner to confirm a transaction.
+    /// @param transactionId Transaction ID.
+    function confirmTransaction(uint transactionId)
+        public
+        ownerExists(msg.sender)
+        transactionExists(transactionId)
+        notConfirmed(transactionId, msg.sender)
+    {
+        confirmations[transactionId][msg.sender] = true;
+        emit Confirmation(msg.sender, transactionId);
+        executeTransaction(transactionId);
+    }
+
+    /// @dev Allows an owner to revoke a confirmation for a transaction.
+    /// @param transactionId Transaction ID.
+    function revokeConfirmation(uint transactionId)
+        public
+        ownerExists(msg.sender)
+        confirmed(transactionId, msg.sender)
+        notExecuted(transactionId)
+    {
+        confirmations[transactionId][msg.sender] = false;
+        emit Revocation(msg.sender, transactionId);
+    }
+
+    /// @dev Allows anyone to execute a confirmed transaction.
+    /// @param transactionId Transaction ID.
+    function executeTransaction(uint transactionId)
+        public
+        ownerExists(msg.sender)
+        confirmed(transactionId, msg.sender)
+        notExecuted(transactionId)
+    {
+        if (isConfirmed(transactionId)) {
+            Transaction storage txn = transactions[transactionId];
+            txn.executed = true;
+            if (txn.txType == 1 && addOwner(txn.destination))
+                emit Execution(transactionId);
+            else if (txn.txType == 2 && removeOwner(txn.destination))
+                emit Execution(transactionId);
+            else if (txn.txType > 2){
+                doExecute(transactionId, txn.txType, txn.data);
+            }
+            else {
+                emit ExecutionFailure(transactionId);
+                txn.executed = false;
+            }
+        }
+    }
+
+    /// @dev Returns the confirmation status of a transaction.
+    /// @param transactionId Transaction ID.
+    /// @return Confirmation status.
+    function isConfirmed(uint transactionId)
+        public
+        view
+        returns (bool)
+    {
+        uint count = 0;
+        for (uint i=0; i<owners.length; i++) {
+            if (confirmations[transactionId][owners[i]])
+                count += 1;
+            if (count == required)
+                return true;
+        }
+    }
+
+    /*
+     * Internal functions
+     */
+    /// @dev Adds a new transaction to the transaction mapping, if transaction does not exist yet.
+    /// @param destination Transaction target address.
+    /// @param data Transaction wei value.
+    /// @return Returns transaction ID.
+    function addTransaction(address destination, bytes memory data, uint txType)
+        internal
+        notNull(destination)
+        returns (uint transactionId)
+    {
+        transactionId = transactionCount;
+        transactions[transactionId] = Transaction({
+            destination: destination,
+            txType: txType,
+            data: data,
+            executed: false
+        });
+        transactionCount += 1;
+        emit Submission(transactionId);
+    }
+
+    /*
+     * Call functions
+     */
+    /// @dev Returns number of confirmations of a transaction.
+    /// @param transactionId Transaction ID.
+    /// @return Number of confirmations.
+    function getConfirmationCount(uint transactionId)
+        public
+        view
+        returns (uint count)
+    {
+        for (uint i=0; i<owners.length; i++)
+            if (confirmations[transactionId][owners[i]])
+                count += 1;
+    }
+
+    /// @dev Returns total number of transactions after filers are applied.
+    /// @param pending Include pending transactions.
+    /// @param executed Include executed transactions.
+    /// @return Total number of transactions after filters are applied.
+    function getTransactionCount(bool pending, bool executed)
+        public
+        view
+        returns (uint count)
+    {
+        for (uint i=0; i<transactionCount; i++)
+            if (   pending && !transactions[i].executed
+                || executed && transactions[i].executed)
+                count += 1;
+    }
+
+    /// @dev Returns list of owners.
+    /// @return List of owner addresses.
+    function getOwners()
+        public
+        view
+        returns (address[] memory)
+    {
+        return owners;
+    }
+
+    /// @dev Returns array with owner addresses, which confirmed transaction.
+    /// @param transactionId Transaction ID.
+    /// @return Returns array of owner addresses.
+    function getConfirmations(uint transactionId)
+        public
+        view
+        returns (address[] memory _confirmations)
+    {
+        address[] memory confirmationsTemp = new address[](owners.length);
+        uint count = 0;
+        uint i;
+        for (i=0; i<owners.length; i++)
+            if (confirmations[transactionId][owners[i]]) {
+                confirmationsTemp[count] = owners[i];
+                count += 1;
+            }
+        _confirmations = new address[](count);
+        for (i=0; i<count; i++)
+            _confirmations[i] = confirmationsTemp[i];
+    }
+}

--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@
 This repository includes all contracts that deploy on HARA private network (HARA chain).
 
 ## Contracts Definition
-
+## Interfaces
 ### [IBuyable Interface](contracts/interfaces/IBuyable.sol)
 Interface for buyable item.
 
@@ -25,6 +25,8 @@ Interface for withdrawable contract.
 
 ### [AdvancedPrice Contract](contracts/AdvancedPrice.sol)
 Contract for advanced price. Exchange rate use case. Price will change based on exchange rate.
+
+## Contracts
 
 ### [BasicMarketItem Contract](contracts/BasicMarketItem.sol)
 Basic contract for item on data exchange market.
@@ -49,3 +51,21 @@ Contract oh ERC20 HaraToken on HARA chain network.
 
 ### [Order Contract](contracts/Order.sol)
 Contract to that allow user to buy multiple data in one transaction.
+
+## Hara Name Services
+ENS for hara network.
+### [ENS Contract](contracts/ens/ENS.sol)
+Ethereum name services abstraction.
+
+### [HNS Contract](contracts/ens/HNS.sol)
+Hara Name Services Registry contract,
+
+### [HaraRegistrar Contract](contracts/ens/HaraRegistrar.sol)
+Registrar to regist new node by staking with hart.
+
+### [OwnerRegistrar Contract](contracts/ens/OwnerRegistrar.sol)
+Registrar to regist new node by owner only.
+
+### [HaraResolver](contracts/ens/HNS.sol)
+Contract to keep all resolvers of nodes. Accept address, ABI, PubKey, content, name, text.
+

--- a/test/DataFactory.test.js
+++ b/test/DataFactory.test.js
@@ -82,7 +82,7 @@ describe('create data store contract with signature function', async function ()
   });
 
   it('store data signature', async function () {
-    var dataSignature = await datastore1.getSignature();
+    var dataSignature = await datastore1.getSignature(web3.utils.keccak256("0"));
     assert.strictEqual(web3.utils.hexToAscii(dataSignature), initSignature);
   });
 
@@ -125,7 +125,7 @@ describe('create data store contract without signature function', async function
   });
 
   it('store data signature', async function () {
-    var dataSignature = await datastore2.getSignature();
+    var dataSignature = await datastore2.getSignature(web3.utils.keccak256("0"));
     assert.strictEqual(web3.utils.hexToAscii(dataSignature), initSignature);
   });
 

--- a/test/DataFactoryProvider.test.js
+++ b/test/DataFactoryProvider.test.js
@@ -1,0 +1,150 @@
+const DataFactoryProvider = artifacts.require("DataFactoryProvider");
+const DataFactoryContract = artifacts.require("DataFactory");
+const DataProvider = artifacts.require("DataProviderRelation");
+const DataStoreContract = artifacts.require("DataStore");
+
+const expectRevert = require("./helpers/expectRevert");
+const encoderDecoder = require("./helpers/encoderDecoder");
+const logsDetail = require("./helpers/LogsHelper");
+
+contract("DataFactoryProvider", accounts => {
+  let datafactoryprovider;
+  let dataprovider;
+  let datafactory;
+  let datastore1;
+  let datastore2;
+  let hart;
+
+  const initSignature = web3.utils.keccak256("this is test");
+  const initSignatureFunc = "keccak";
+
+  const factoryRegistryOwner = accounts[0];
+  const factoryOwner = accounts[0];
+  const dataOwner = accounts[1];
+  const notOwner = accounts[2];
+  const providerOwner = accounts[3];
+  const dummyHart = accounts[4];
+  const dummyDFRegistry = accounts[5];
+  const allowedAddress1 = accounts[6];
+
+  const DataCreationLogTopic = logsDetail.DataFactory.DataCreationLogTopic;
+  const DataCreationLogAbi = logsDetail.DataFactory.DataCreationLogAbi;
+
+  //   const DataFactoryAddressChangedLogTopic = logsDetail.datafactoryprovider.DataFactoryAddressChangedLogTopic;
+  //   const DataFactoryAddressChangedLogAbi = logsDetail.datafactoryprovider.DataFactoryAddressChangedLogAbi;
+
+  //   const AllowedAddressLogTopic = logsDetail.datafactoryprovider.AllowedAddressLogTopic;
+  //   const AllowedAddressLogAbi = logsDetail.datafactoryprovider.AllowedAddressLogAbi;
+
+  before(async function() {
+    // deploy hara token contract
+    // var haratokenContract = new web3.eth.Contract(HaraToken.abi);
+    // hart = await haratokenContract.deploy({
+    //   data: HaraToken.bytecode
+    // }).send({
+    //   from: owner,
+    //   gas: 4700000
+    // });
+    // initHartAddress = hart.options.address;
+
+    // await hart.methods.mint(owner, web3.utils.toWei("1000")).send({
+    //   from: owner
+    // });
+    // deploy datafactory
+    datafactory = await DataFactoryContract.new(dummyHart, {
+      from: factoryOwner
+    });
+
+    // deploy dataprovider
+    dataprovider = await DataProvider.new({
+      from: providerOwner
+    });
+
+    // create data contract for relation
+    const receipt = await datafactory.storeData(
+      dataOwner,
+      dataprovider.address,
+      initSignature,
+      web3.utils.asciiToHex(initSignatureFunc),
+      dummyDFRegistry,
+      {
+        from: allowedAddress1
+      }
+    );
+    const logs = receipt.receipt.rawLogs;
+    const DataCreationLog = encoderDecoder.decodeLogsByTopic(
+      DataCreationLogTopic,
+      DataCreationLogAbi,
+      logs
+    )[0];
+    datastore1 = await DataStoreContract.at(
+      DataCreationLog.contractDataAddress
+    );
+
+    // deplot datafactory provider
+    datafactoryprovider = await DataFactoryProvider.new(
+      datastore1.address,
+      dataprovider.address,
+      {
+        from: factoryRegistryOwner
+      }
+    );
+
+    // set datafactoryprovider as editor
+    await datastore1.setEditor(datafactoryprovider.address, {from: dataOwner});
+    
+    // set provider proxy
+    await dataprovider.setProxyAddress(datafactoryprovider.address, {from: providerOwner});
+  });
+
+  it("have owner", async function() {
+    var owner = await datafactoryprovider.owner();
+    assert.strictEqual(owner, factoryRegistryOwner);
+  });
+
+  it("store current data store", async function() {
+    var ds = await datafactoryprovider.dataStore();
+    assert.strictEqual(ds.toString(), datastore1.address);
+  });
+
+  it("store current data provider", async function() {
+    var dp = await datafactoryprovider.dataProvider();
+    assert.strictEqual(dp.toString(), dataprovider.address);
+  });
+    describe('new version', async function () {
+      it('store new version signature and value', async function () {
+        var receipt = await datafactoryprovider.addNewVersion(
+          web3.utils.soliditySha3({t:'string',v:"1"}),
+          web3.utils.keccak256("this is signature 1"),
+          datastore1.address,
+          "1",
+          datastore1.address,
+          "2",
+          {from: factoryRegistryOwner }
+        );
+        
+        const newSignature = await datastore1.getSignature(web3.utils.soliditySha3({t:'string',v:"1"}));
+        assert.strictEqual(newSignature, web3.utils.keccak256("this is signature 1"));
+
+        const newValue = await dataprovider.getUri(datastore1.address, "1");
+        assert.strictEqual(newValue, datastore1.address + "2");
+      });
+
+      it('cannot set new version by not owner', async function () {
+        await expectRevert(datafactoryprovider.addNewVersion(
+          web3.utils.soliditySha3({t:'string',v:"2"}),
+          web3.utils.keccak256("this is signature 2"),
+          datastore1.address,
+          web3.utils.soliditySha3({t:'string',v:"2"}),
+          datastore1.address,
+          "3",
+          {from: notOwner }
+        ));
+        const newSignature = await datastore1.getSignature(web3.utils.soliditySha3({t:'string',v:"2"}));
+        assert.notStrictEqual(newSignature, web3.utils.keccak256("this is signature 2"));
+
+        const newValue = await dataprovider.getUri(datastore1.address, "2");
+        assert.notStrictEqual(newValue, datastore1.address + "3");
+      });
+    });
+});

--- a/test/DataFactoryRegistry.test.js
+++ b/test/DataFactoryRegistry.test.js
@@ -193,7 +193,7 @@ contract('DataFactoryRegistry', accounts => {
     });
 
     it('store data signature', async function () {
-      var dataSignature = await datastore1.getSignature();
+      var dataSignature = await datastore1.getSignature(web3.utils.keccak256("0"));
       assert.strictEqual(web3.utils.hexToAscii(dataSignature), initSignature);
     });
 
@@ -235,7 +235,7 @@ contract('DataFactoryRegistry', accounts => {
     });
 
     it('store data signature', async function () {
-      var dataSignature = await datastore2.getSignature();
+      var dataSignature = await datastore2.getSignature(web3.utils.keccak256("0"));
       assert.strictEqual(web3.utils.hexToAscii(dataSignature), initSignature);
     });
 

--- a/test/DataProviderNull.test.js
+++ b/test/DataProviderNull.test.js
@@ -1,0 +1,20 @@
+const expectRevert = require("./helpers/expectRevert");
+
+const DataProviderNull = artifacts.require('DataProviderNull');
+
+contract('DataProviderNull', accounts => {
+  let dataProvider;
+  const owner = accounts[0];
+
+  const initLocatioId = "1";
+  const initPriceId = "0";
+
+  before(async function () {
+    dataProvider = await DataProviderNull.new({ from: owner });
+  });
+
+  it('can get null uri', async function () {
+    const uri = await dataProvider.getUri(initLocatioId, initPriceId);
+    assert.strictEqual(uri, "");
+  });
+});

--- a/test/DataProviderProxy.test.js
+++ b/test/DataProviderProxy.test.js
@@ -1,13 +1,15 @@
 const expectRevert = require("./helpers/expectRevert");
 
+const DataProviderProxy = artifacts.require('DataProviderProxy');
 const DataProviderHara = artifacts.require('DataProviderHara');
 
-contract('DataProviderHara', accounts => {
+contract('DataProviderProxy', accounts => {
   let dataProvider;
+  let dataProviderProxy;
+
   const owner = accounts[0];
   const notOwner = accounts[1];
 
-  // const initLocatioId = web3.utils.asciiToHex("petaniA");
   const initLocatioId = "1";
   const initPriceId = "0";
   const initEndpoint = "http://endpoint.hara.com/get_data";
@@ -15,31 +17,30 @@ contract('DataProviderHara', accounts => {
 
   before(async function () {
     dataProvider = await DataProviderHara.new({ from: owner });
+    dataProviderProxy = await DataProviderProxy.new(dataProvider.address, { from: owner });
+    await dataProvider.setProxyAddress(dataProviderProxy.address, {from: owner});
   });
 
   it('can not get uri because endpoint not set', async function () {
     await expectRevert(
-      dataProvider.getUri(initLocatioId, initPriceId)
+      dataProviderProxy.getUri(initLocatioId, initPriceId)
     );
   });
 
   it('set endpoint by data provider owner', async function () {
-    const receipt = await dataProvider.setEndpoint("0x0", initEndpoint, {from: owner});
-    const log = receipt.receipt.logs[0]
-    assert.strictEqual(log.event, "EndpointChangedLog");
-    assert.strictEqual(log.args.oldEndpoint, "")
-    assert.strictEqual(log.args.newEndpoint, initEndpoint);
-    assert.strictEqual(log.args.by, owner);
+    const receipt = await dataProviderProxy.setEndpoint("0x0", initEndpoint, {from: owner});
+    const log = receipt.receipt.logs[0];
+    assert.strictEqual(log.event, "ProxyLog");
   });
 
   it('can not set endpoint by not owner', async function () {
     await expectRevert(
-      dataProvider.setEndpoint("0x0", initEndpoint, {from: notOwner})
+      dataProviderProxy.setEndpoint("0x0", initEndpoint, {from: notOwner})
     );
   });
 
   it('return Uri', async function () {
-    const uri = await dataProvider.getUri(initLocatioId, initPriceId);
+    const uri = await dataProviderProxy.getUri(initLocatioId, initPriceId);
     assert.strictEqual(initUri, uri);
   });
 });

--- a/test/DataProviderRelation.test.js
+++ b/test/DataProviderRelation.test.js
@@ -1,0 +1,39 @@
+const expectRevert = require("./helpers/expectRevert");
+
+const DataProviderRelation = artifacts.require('DataProviderRelation');
+
+contract('DataProviderRelation', accounts => {
+  let dataProvider;
+  const owner = accounts[0];
+  const notOwner = accounts[1];
+  const dummyData = accounts[2];
+
+  const initVersion1 = "0";
+  const initVersion2 = "1"
+  const dataWithVersion1 = dummyData+initVersion1;
+  const dataWithVersion2 = dummyData+initVersion2;
+
+  before(async function () {
+    dataProvider = await DataProviderRelation.new({ from: owner });
+  });
+
+  it('set endpoint by data provider owner', async function () {
+    const receipt = await dataProvider.setEndpoint(web3.utils.soliditySha3({t:'string', v:dummyData}, {t:'string',v:initVersion1}), dataWithVersion2, {from: owner});
+    const log = receipt.receipt.logs[0]
+    assert.strictEqual(log.event, "EndpointChangedLog");
+    assert.strictEqual(log.args.oldEndpoint, "")
+    assert.strictEqual(log.args.newEndpoint, dataWithVersion2);
+    assert.strictEqual(log.args.by, owner);
+  });
+
+  it('can not set endpoint by not owner', async function () {
+    await expectRevert(
+        dataProvider.setEndpoint(web3.utils.soliditySha3({t:'string', v:dummyData}, {t:'string',v:initVersion1}), "test", {from: notOwner})
+    );
+  });
+
+  it('return Uri', async function () {
+    const uri = await dataProvider.getUri(dummyData, initVersion1);
+    assert.strictEqual(uri, dataWithVersion2);
+  });
+});

--- a/test/DataStore.test.js
+++ b/test/DataStore.test.js
@@ -1,7 +1,6 @@
 const DataStoreContract = artifacts.require('DataStore');
 const DataFactory = artifacts.require('DataFactory');
 const DataFactoryRegistry = artifacts.require('DataFactoryRegistry');
-// const AdvancedPrice= artifacts.require('AdvancedPriceTest');
 const HaraToken = artifacts.require('HaraTokenPrivate');
 const AdvancedPrice = artifacts.require('AdvancedPrice');
 const ExchangeHARTIDR = artifacts.require('ExchangeHARTIDR');
@@ -10,6 +9,7 @@ const ExchangeRate = artifacts.require('ExchangeRate');
 const expectRevert = require("./helpers/expectRevert")
 const expectContractNotExists = require("./helpers/expectContractNotExists")
 const encoderDecoder = require("./helpers/encoderDecoder")
+const logHelper = require("./helpers/LogsHelper")
 
 contract('DataStore', accounts => {
   let datastore;
@@ -32,6 +32,7 @@ contract('DataStore', accounts => {
   const buyer = accounts[3];
   const exchangeOwner = accounts[4];
   const dummyDexAddress = accounts[5];
+  const editor = accounts[6];
 
   before(async function () {
     // deploy hara token contract
@@ -59,6 +60,7 @@ contract('DataStore', accounts => {
       });
 
     await dataFactoryRegistry.setDexAddress(dummyDexAddress, {from:owner});
+    await dataFactoryRegistry.addAllowedAddress(editor, {from: owner});
 
     datastore = await DataStoreContract.new(
       dataOwner,
@@ -118,13 +120,19 @@ contract('DataStore', accounts => {
     });
 
     it('store data signature', async function () {
-      var dataSignature = await datastore.getSignature();
+      var dataSignature = await datastore.getSignature(web3.utils.keccak256("0"));
       assert.strictEqual(web3.utils.hexToAscii(dataSignature), initSignature);
     });
 
     it('store data signature function', async function () {
       var dataSignatureFunc = await datastore.getSignatureFunction();
       assert.strictEqual(web3.utils.hexToAscii(dataSignatureFunc), initSignatureFunc);
+    });
+
+    it('store data signature with other version', async function () {
+      await datastore.setSignature(initPriceId, web3.utils.keccak256("this is test"));
+      var dataSignature = await datastore.getSignature(initPriceId);
+      assert.strictEqual(dataSignature, web3.utils.keccak256("this is test"));
     });
   });
 
@@ -146,40 +154,6 @@ contract('DataStore', accounts => {
       assert.strictEqual(web3.utils.padRight(sizeMetadata, 64), web3.utils.padRight(initValueMetadata[0], 64));
       assert.strictEqual(web3.utils.padRight(filenameMetadata, 64), web3.utils.padRight(initValueMetadata[1], 64));
     });
-
-    // it('can\'t init price by not owner', async function () {
-    //   await expectRevert(
-    //     datastore.setPrice(initPriceId, initPriceValue, {
-    //       from: notOwner
-    //     })
-    //   );
-    // });
-
-    // it('set price by owner', async function () {
-    //   datastore.setPrice(initPriceId, initPriceValue, {
-    //     from: dataOwner
-    //   });
-    //   var price = await datastore.getPrice(initPriceId);
-    //   var isSale = await datastore.isSale(initPriceId);
-    //   assert.strictEqual(price.toString(), initPriceValue);
-    //   assert.strictEqual(isSale, false);
-    // });
-
-    // it('can\'t set sale by not owner', async function () {
-    //   await expectRevert(
-    //     datastore.setSale(initPriceId, true, {
-    //       from: notOwner
-    //     })
-    //   );
-    // });
-
-    // it('set sale status by owner', async function () {
-    //   await datastore.setSale(initPriceId, true, {
-    //     from: dataOwner
-    //   });
-    //   var isSale = await datastore.isSale(initPriceId);
-    //   assert.strictEqual(isSale, true);
-    // });
   });
 
   describe('add additional data and details', async function () {
@@ -205,138 +179,6 @@ contract('DataStore', accounts => {
     });
   });
 
-  // describe('buy data', async function () {
-  //   before(async function () {
-  //     await hart.methods.transfer(buyer, web3.utils.toWei("100")).send({
-  //       from: owner
-  //     });
-  //   });
-
-  //   it('can buy id 0 with hart', async function () {
-  //     var haraBefore = await hart.methods.balanceOf(owner).call() / 10000000;
-  //     var locationBefore = await hart.methods.balanceOf(initLocation).call() / 10000000;
-
-  //     await hart.methods.buy(datastore.address, initPriceId, web3.utils.toWei("20")).send({
-  //       from: buyer,
-  //       gas: 3000000
-  //     });
-  //     var receipt = await hart.methods.getReceipt(1).call();
-  //     assert.strictEqual(receipt.buyer, buyer);
-  //     assert.strictEqual(receipt.seller, datastore.address);
-  //     assert.strictEqual(receipt.id.toString(), web3.utils.padRight(initPriceId, 64));
-  //     assert.strictEqual(receipt.value.toString(), web3.utils.toWei("20"));
-
-  //     var permission = await datastore.getPurchaseStatus(buyer, initPriceId);
-  //     assert.strictEqual(permission, true);
-
-  //     var haraAfter = await hart.methods.balanceOf(owner).call() / 10000000;
-  //     var locationAfter = await hart.methods.balanceOf(initLocation).call() / 10000000;
-
-  //     assert.strictEqual(haraAfter - haraBefore, web3.utils.toWei("20") * 0.15 / 10000000)
-  //     assert.strictEqual(locationAfter - locationBefore, web3.utils.toWei("20") * 0.05 / 10000000)
-  //   });
-
-  //   it('status is false for id 1', async function () {
-  //     var permission = await datastore.getPurchaseStatus(buyer, web3.utils.fromAscii("1"));
-  //     assert.strictEqual(permission, false);
-  //   });
-
-  //   it('can not buy directly to data store', async function () {
-  //     await expectRevert(datastore.buy("1", {
-  //       from: buyer
-  //     }));
-  //   });
-  // });
-
-  // describe('purchased data permission', async function () {
-  //   it('true if owner', async function () {
-  //     var isAllowed = await datastore.getPurchaseStatus(dataOwner, initPriceId, {
-  //       from: dataOwner
-  //     });
-  //     assert.strictEqual(isAllowed, true);
-  //   });
-
-  //   it('true if buyer already purchased', async function () {});
-
-  //   it('false if buyer not bought yet', async function () {});
-  // });
-
-  // describe('contract is Withdrawable', async function () {
-  //   before(async function () {
-  //     await hart.methods.transfer(datastore.address, web3.utils.toWei("10")).send({
-  //       from: owner
-  //     });
-  //   });
-
-  //   it('can withdraw by owner', async function () {
-  //     var receipt = await datastore.withdraw(dataOwner, web3.utils.toWei("10"), {
-  //       from: dataOwner
-  //     });
-  //     var BoughtLog = receipt.logs[0];
-  //     assert.strictEqual(BoughtLog.event, "WithdrawnLog");
-  //     assert.strictEqual(BoughtLog.args.to.toString(), dataOwner);
-  //     assert.strictEqual(BoughtLog.args.from.toString(), datastore.address);
-  //     assert.strictEqual(BoughtLog.args.value.toString(), web3.utils.toWei("10"));
-  //   });
-
-  //   it('can not withdraw by not owner', async function () {
-  //     await expectRevert(
-  //       datastore.withdraw(dataOwner, web3.utils.toWei("10"), {
-  //         from: notOwner
-  //       })
-  //     );
-  //   });
-  //   it('can not withdraw if no hart to withdraw', async function () {
-  //     await expectRevert(
-  //       datastore.withdraw(dataOwner, web3.utils.toWei("1000"), {
-  //         from: dataOwner
-  //       })
-  //     );
-  //   });
-  // });
-
-
-  // describe('contract price using external contract', async function () {
-  //   it('can set price address by owner non external price contract', async function () {
-  //     var receipt = await datastore.setPriceAddress(ap.address, {
-  //       from: dataOwner
-  //     });
-  //     var currentAddress = await datastore.priceAddress();
-  //     assert.strictEqual(currentAddress.toLowerCase(), ap.address.toLowerCase());
-
-  //     var PriceAddressChangedLog = receipt.logs[0];
-  //     assert.strictEqual(PriceAddressChangedLog.event, "PriceAddressChangedLog");
-  //     assert.strictEqual(PriceAddressChangedLog.args.by.toLowerCase(), dataOwner.toLowerCase());
-  //     assert.strictEqual(PriceAddressChangedLog.args.oldAddress.toString(), "0x0000000000000000000000000000000000000000");
-  //     assert.strictEqual(PriceAddressChangedLog.args.newAddress.toLowerCase(), ap.address.toLowerCase());
-  //   });
-
-  //   it('can not set price by not owner', async function () {
-  //     await expectRevert(
-  //       datastore.setPriceAddress(ap.address, {
-  //         from: notOwner
-  //       })
-  //     );
-  //   });
-
-  //   it('can set price using external contract by owner', async function () {
-  //     var receipt = await datastore.setPrice(initPriceId, "5000", {
-  //       from: dataOwner
-  //     });
-
-  //     var logs = receipt.logs;
-  //     assert.strictEqual(logs[0].event, "PriceChangedLog");
-  //     assert.strictEqual(logs[0].args.id, web3.utils.padRight(initPriceId, 64));
-  //     assert.strictEqual(logs[0].args.oldValue.toString(), "0");
-  //     assert.strictEqual(logs[0].args.newValue.toString(), "5000");
-  //   });
-
-  //   it('can get price using external contract', async function () {
-  //     var currentPrice = await datastore.getPrice(initPriceId);
-  //     assert.strictEqual(currentPrice.toString(), "50");
-  //   });
-  // });
-
   describe('purchase status', async function () {
     it('can set purchase status by Dex address', async function () {
       var purchaseStatusBefore = await datastore.getPurchaseStatus(buyer, initPriceId);
@@ -360,6 +202,90 @@ contract('DataStore', accounts => {
         datastore.setPurchaseStatus(initPriceId, notOwner, true, {
           from: notOwner
         }));
+    });
+  });
+
+  describe('have editor', async function () {
+    it('set editor by owner', async function () {
+      var editorBefore = await datastore.editor();
+      await datastore.setEditor(editor, {
+        from: dataOwner
+      })
+
+      var editorAfter = await datastore.editor();
+      assert.strictEqual(editorBefore, "0x0000000000000000000000000000000000000000");
+      assert.strictEqual(editorAfter, editor);
+      assert.notStrictEqual(editorBefore, editorAfter);
+    });
+
+    it('can not set editor by not owner', async function () {
+      var editorBefore = await datastore.editor();
+      await expectRevert(
+        datastore.setEditor(dummyDexAddress, {from: notOwner})
+      )
+
+      var editorAfter = await datastore.editor();
+      assert.strictEqual(editorBefore, editor);
+      assert.strictEqual(editorAfter, editor);
+      assert.strictEqual(editorBefore, editorAfter);
+    });
+
+    it('set signature by editor', async function () {
+      var signatureBefore = await datastore.getSignature(web3.utils.keccak256("1"));
+      await datastore.setSignature(web3.utils.keccak256("1"), web3.utils.asciiToHex("this is signature test 1"), {
+        from: editor
+      })
+
+      var signatureAfter = await datastore.getSignature(web3.utils.keccak256("1"));
+      assert.strictEqual(signatureBefore, null);
+      assert.strictEqual(signatureAfter, web3.utils.asciiToHex("this is signature test 1"));
+      assert.notStrictEqual(signatureBefore, signatureAfter);
+    });
+
+    it('set signature by owner', async function () {
+      var signatureBefore = await datastore.getSignature(web3.utils.keccak256("2"));
+      await datastore.setSignature(web3.utils.keccak256("2"), web3.utils.asciiToHex("this is signature test 2"), {
+        from: editor
+      })
+
+      var signatureAfter = await datastore.getSignature(web3.utils.keccak256("2"));
+      assert.strictEqual(signatureBefore, null);
+      assert.strictEqual(signatureAfter, web3.utils.asciiToHex("this is signature test 2"));
+      assert.notStrictEqual(signatureBefore, signatureAfter);
+    });
+
+    it('not set signature by notOwner', async function () {
+      var signatureBefore = await datastore.getSignature(web3.utils.keccak256("3"));
+      await expectRevert(datastore.setSignature(web3.utils.keccak256("3"), web3.utils.asciiToHex("this is signature test 3"), {
+        from: notOwner
+      })
+      )
+
+      var signatureAfter = await datastore.getSignature(web3.utils.keccak256("3"));
+      assert.strictEqual(signatureBefore, null);
+      assert.strictEqual(signatureAfter, null);
+      assert.strictEqual(signatureBefore, signatureAfter);
+    });
+  });
+
+  describe('have getClass()', async function () {
+    it('emit hasGetClass event', async function () {
+      const receipt = await dataFactoryRegistry.storeData2(
+        dataOwner,
+        initLocation,
+        web3.utils.asciiToHex(initSignature), {
+          from: editor
+        }
+      );
+      const HasGetLog = encoderDecoder.decodeLogsByTopic(logHelper.ContractMadeAbstract.HasGetClassTopic,
+        logHelper.ContractMadeAbstract.HasGetClassAbi, receipt.receipt.rawLogs);
+        assert.strictEqual(HasGetLog.length, 1);
+        assert.strictEqual(HasGetLog[0].__length__, 0)
+    });
+
+    it('can get class with getClass() function', async function () {
+      const hns = await datastore.getClass()
+      assert.strictEqual(hns, "datastore.class");
     });
   });
 

--- a/test/ens/HNS.test.js
+++ b/test/ens/HNS.test.js
@@ -1,8 +1,6 @@
 const HNS = artifacts.require('./HNSRegistry');
 
-const expectRevert = require("./helpers/expectRevert");
-const encoderDecoder = require("./helpers/encoderDecoder");
-const logsDetail = require("./helpers/LogsHelper");
+const expectRevert = require("./../helpers/expectRevert");
 
 contract('HNS', accounts => {
     let hnsRegistry;
@@ -67,102 +65,6 @@ contract('HNS', accounts => {
         });
     });
 
-    describe('set and change owner of subnode', async function () {
-        it('set .hara tld', async function () {
-            var ownerBefore = await hnsRegistry.owner(haraNamehash);
-            var receipt = await hnsRegistry.setSubnodeOwner("0x0", haraHash, haraOwner, {
-                from: rootOwner1
-            });
-            var ownerAfter = await hnsRegistry.owner(haraNamehash);
-            assert.strictEqual(ownerBefore, "0x0000000000000000000000000000000000000000");
-            assert.strictEqual(ownerAfter, haraOwner);
-            assert.notStrictEqual(ownerBefore, ownerAfter)
-
-            const log = receipt.receipt.logs[0];
-            assert.strictEqual(log.event, "NewOwner");
-            assert.strictEqual(log.args.node, "0x0000000000000000000000000000000000000000000000000000000000000000");
-            assert.strictEqual(log.args.label, haraHash);
-            assert.strictEqual(log.args.owner, haraOwner);
-        });
-
-        it('can not set .test tld  by not owner', async function () {
-            await expectRevert(
-                hnsRegistry.setSubnodeOwner("0x0", web3.utils.sha3("test"), notOwner, {
-                    from: notOwner
-                })
-            );
-        });
-
-        it('set dev.hara domain', async function () {
-            var ownerBefore = await hnsRegistry.owner(devharaNamehash);
-            var receipt = await hnsRegistry.setSubnodeOwner(haraNamehash, devHash, devharaOwner, {
-                from: haraOwner
-            });
-            var ownerAfter = await hnsRegistry.owner(devharaNamehash);
-            assert.strictEqual(ownerBefore, "0x0000000000000000000000000000000000000000");
-            assert.strictEqual(ownerAfter, devharaOwner);
-            assert.notStrictEqual(ownerBefore, ownerAfter)
-
-            const log = receipt.receipt.logs[0];
-            assert.strictEqual(log.event, "NewOwner");
-            assert.strictEqual(log.args.node, haraNamehash);
-            assert.strictEqual(log.args.label, devHash);
-            assert.strictEqual(log.args.owner, devharaOwner);
-        });
-    });
-
-    describe('set resolver', async function () {
-        it('can set resolver by owner', async function () {
-            var resolverBefore = await hnsRegistry.resolver(devharaNamehash);
-            var receipt = await hnsRegistry.setResolver(devharaNamehash, dummyResolver, {
-                from: devharaOwner
-            });
-            var resolverAfter = await hnsRegistry.resolver(devharaNamehash);
-            assert.strictEqual(resolverBefore, "0x0000000000000000000000000000000000000000");
-            assert.strictEqual(resolverAfter, dummyResolver);
-            assert.notStrictEqual(resolverBefore, resolverAfter)
-
-            const log = receipt.receipt.logs[0];
-            assert.strictEqual(log.event, "NewResolver");
-            assert.strictEqual(log.args.node, devharaNamehash);
-            assert.strictEqual(log.args.resolver, dummyResolver);
-        });
-
-        it('can not set resolver by not owner', async function () {
-            await expectRevert(
-                hnsRegistry.setResolver(devharaNamehash, dummyResolver, {
-                    from: notOwner
-                })
-            )
-        })
-    });
-
-    describe('set ttl', async function () {
-        it('can set ttl by owner', async function () {
-            var ttlBefore = await hnsRegistry.ttl(devharaNamehash);
-            var receipt = await hnsRegistry.setTTL(devharaNamehash, 5, {
-                from: devharaOwner
-            });
-            var ttlAfter = await hnsRegistry.ttl(devharaNamehash);
-            assert.strictEqual(ttlBefore.toString(), "0");
-            assert.strictEqual(ttlAfter.toString(), "5");
-            assert.notStrictEqual(ttlBefore, ttlAfter)
-
-            const log = receipt.receipt.logs[0];
-            assert.strictEqual(log.event, "NewTTL");
-            assert.strictEqual(log.args.node, devharaNamehash);
-            assert.strictEqual(log.args.ttl.toString(), "5");
-        });
-
-        it('can not set resolver by not owner', async function () {
-            await expectRevert(
-                hnsRegistry.setResolver(devharaNamehash, dummyResolver, {
-                    from: notOwner
-                })
-            )
-        })
-    });
-
     describe('have activeRegistrar', async function () {
         it('can set registrar by owner', async function () {
             var registrarBefore = await hnsRegistry.activeRegistrar();
@@ -188,7 +90,7 @@ contract('HNS', accounts => {
             )
         });
 
-        it('can set new subnode by registrar if registrar is set', async function () {
+        it('can set new subnode by registrar', async function () {
             var ownerBefore = await hnsRegistry.owner("0xc228250cd567687ff7faee5c63fb721b525b63beaba08a87df1eeaea0120f79d");
             var receipt = await hnsRegistry.setSubnodeOwner(devharaNamehash, "0x8c9e37c3d5f4d11153908eeaa7d86bcdf59b3478f4b3854a0ac463b58b1110d9",
             devharaOwner, {
@@ -214,5 +116,101 @@ contract('HNS', accounts => {
                 })
             )
         });
+    });
+
+    describe('set and change owner of subnode', async function () {
+        it('set .hara tld', async function () {
+            var ownerBefore = await hnsRegistry.owner(haraNamehash);
+            var receipt = await hnsRegistry.setSubnodeOwner("0x0", haraHash, haraOwner, {
+                from: dummyRegistrar
+            });
+            var ownerAfter = await hnsRegistry.owner(haraNamehash);
+            assert.strictEqual(ownerBefore, "0x0000000000000000000000000000000000000000");
+            assert.strictEqual(ownerAfter, haraOwner);
+            assert.notStrictEqual(ownerBefore, ownerAfter)
+
+            const log = receipt.receipt.logs[0];
+            assert.strictEqual(log.event, "NewOwner");
+            assert.strictEqual(log.args.node, "0x0000000000000000000000000000000000000000000000000000000000000000");
+            assert.strictEqual(log.args.label, haraHash);
+            assert.strictEqual(log.args.owner, haraOwner);
+        });
+
+        it('can not set .test tld  by not owner', async function () {
+            await expectRevert(
+                hnsRegistry.setSubnodeOwner("0x0", web3.utils.sha3("test"), notOwner, {
+                    from: notOwner
+                })
+            );
+        });
+
+        it('set dev.hara domain', async function () {
+            var ownerBefore = await hnsRegistry.owner(devharaNamehash);
+            var receipt = await hnsRegistry.setSubnodeOwner(haraNamehash, devHash, devharaOwner, {
+                from: dummyRegistrar
+            });
+            var ownerAfter = await hnsRegistry.owner(devharaNamehash);
+            assert.strictEqual(ownerBefore, "0x0000000000000000000000000000000000000000");
+            assert.strictEqual(ownerAfter, devharaOwner);
+            assert.notStrictEqual(ownerBefore, ownerAfter)
+
+            const log = receipt.receipt.logs[0];
+            assert.strictEqual(log.event, "NewOwner");
+            assert.strictEqual(log.args.node, haraNamehash);
+            assert.strictEqual(log.args.label, devHash);
+            assert.strictEqual(log.args.owner, devharaOwner);
+        });
+    });
+
+    describe('set resolver', async function () {
+        it('can set resolver only by root owner', async function () {
+            var resolverBefore = await hnsRegistry.resolver(devharaNamehash);
+            var receipt = await hnsRegistry.setResolver("0x00", dummyResolver, {
+                from: rootOwner1
+            });
+            var resolverAfter = await hnsRegistry.resolver(devharaNamehash);
+            assert.strictEqual(resolverBefore, "0x0000000000000000000000000000000000000000");
+            assert.strictEqual(resolverAfter, dummyResolver);
+            assert.notStrictEqual(resolverBefore, resolverAfter)
+
+            const log = receipt.receipt.logs[0];
+            assert.strictEqual(log.event, "NewResolver");
+            assert.strictEqual(log.args.node, "0x0000000000000000000000000000000000000000000000000000000000000000");
+            assert.strictEqual(log.args.resolver, dummyResolver);
+        });
+
+        it('can not set resolver by not root owner', async function () {
+            await expectRevert(
+                hnsRegistry.setResolver(devharaNamehash, dummyResolver, {
+                    from: notOwner
+                })
+            )
+        })
+    });
+
+    describe('set ttl', async function () {
+        it('can set ttl by owner', async function () {
+            var ttlBefore = await hnsRegistry.ttl(devharaNamehash);
+            var receipt = await hnsRegistry.setTTL(devharaNamehash, 5, {
+                from: devharaOwner
+            });
+            var ttlAfter = await hnsRegistry.ttl(devharaNamehash);
+            assert.strictEqual(ttlBefore.toString(), "0");
+            assert.strictEqual(ttlAfter.toString(), "5");
+            assert.notStrictEqual(ttlBefore, ttlAfter)
+
+            const log = receipt.receipt.logs[0];
+            assert.strictEqual(log.event, "NewTTL");
+            assert.strictEqual(log.args.node, devharaNamehash);
+            assert.strictEqual(log.args.ttl.toString(), "5");
+        });
+
+        it('can not set ttl by not owner', async function () {
+            await expectRevert(
+                hnsRegistry.setTTL(devharaNamehash, 5, {
+                    from: notOwner
+                })
+            )
+        })
     });
 });

--- a/test/ens/HaraRegistrar.test.js
+++ b/test/ens/HaraRegistrar.test.js
@@ -2,9 +2,7 @@ const HNS = artifacts.require('./HNSRegistry');
 const Registrar = artifacts.require('./HaraRegistrar');
 const HaraToken = artifacts.require('./HaraTokenPrivate');
 
-const expectRevert = require("./helpers/expectRevert");
-const encoderDecoder = require("./helpers/encoderDecoder");
-const logsDetail = require("./helpers/LogsHelper");
+const expectRevert = require("./../helpers/expectRevert");
 
 contract('HaraRegistrar', accounts => {
     let hart;
@@ -17,6 +15,7 @@ contract('HaraRegistrar', accounts => {
     const registrarOwner = accounts[3];
     const blockchaindevharaOwner = accounts[4];
     const agentdevharaOwner = accounts[5];
+    const dummyRegistrar = accounts[6];
 
     const haraHash = web3.utils.sha3("hara");
     const devHash = web3.utils.sha3("dev");
@@ -45,19 +44,24 @@ contract('HaraRegistrar', accounts => {
             {
             from: registrarOwner
         });
+
+        await hnsRegistry.setRegistrar(dummyRegistrar, {
+            from: rootOwner
+        });
+
         // add .hara tld
         await hnsRegistry.setSubnodeOwner("0x0", haraHash, haraOwner, {
-            from: rootOwner
+            from: dummyRegistrar
         });
 
         // add dev.hara domain
         await hnsRegistry.setSubnodeOwner(haraNamehash, devHash, devharaOwner, {
-            from: haraOwner
+            from: dummyRegistrar
         });
 
         // add agent.dev.hara domain
         await hnsRegistry.setSubnodeOwner(devharaNamehash, agentHash, agentdevharaOwner, {
-            from: devharaOwner
+            from: dummyRegistrar
         });
     });
 

--- a/test/ens/HaraResolver.test.js
+++ b/test/ens/HaraResolver.test.js
@@ -1,9 +1,7 @@
 const HNS = artifacts.require('./HNSRegistry');
 const Resolver = artifacts.require('./HaraResolver');
 
-const expectRevert = require("./helpers/expectRevert");
-const encoderDecoder = require("./helpers/encoderDecoder");
-const logsDetail = require("./helpers/LogsHelper");
+const expectRevert = require("./../helpers/expectRevert");
 
 contract('HaraResolver', accounts => {
     let hnsRegistry;
@@ -13,6 +11,7 @@ contract('HaraResolver', accounts => {
     const haraOwner = accounts[1];
     const devharaOwner = accounts[2];
     const notOwner = accounts[4];
+    const dummyRegistrar = accounts[5];
 
     const haraHash = web3.utils.sha3("hara");
     const devHash = web3.utils.sha3("dev");
@@ -26,14 +25,18 @@ contract('HaraResolver', accounts => {
             from: rootOwner
         });
 
+        await hnsRegistry.setRegistrar(dummyRegistrar, {
+            from: rootOwner
+        });
+
         // add .hara tld
         await hnsRegistry.setSubnodeOwner("0x0", haraHash, haraOwner, {
-            from: rootOwner
+            from: dummyRegistrar
         });
 
         // add dev.hara domain
         await hnsRegistry.setSubnodeOwner(haraNamehash, devHash, devharaOwner, {
-            from: haraOwner
+            from: dummyRegistrar
         });
 
         // deploy resolver

--- a/test/ens/OwnerRegistrar.test.js
+++ b/test/ens/OwnerRegistrar.test.js
@@ -1,0 +1,61 @@
+const HNS = artifacts.require('./HNSRegistry');
+const Registrar = artifacts.require('./OwnerRegistrar');
+
+const expectRevert = require("./../helpers/expectRevert");
+
+contract('OwnerRegistrar', accounts => {
+    let hnsRegistry;
+    let registrar;
+
+    const rootOwner = accounts[0];
+    const haraOwner = accounts[1];
+    const devharaOwner = accounts[2];
+    const registrarOwner = accounts[3];
+    const notOwner = accounts[4];
+
+    const haraHash = web3.utils.sha3("hara");
+    const devHash = web3.utils.sha3("dev");
+
+    const haraNamehash = "0x55bd9b4e23672e6dd82f8b7bd349e5722479ad1e90582f51cce66772ab933bf5";
+    const devharaNamehash = "0xd93cd5307735da7b67876b30e536dea4e0c19ad7c528f196f2e22648dec8dc3f";
+
+    before(async function () {
+        // deploy hns contract
+        hnsRegistry = await HNS.new({
+            from: rootOwner
+        });
+
+        // deploy registrar
+        registrar = await Registrar.new(
+            hnsRegistry.address,
+            {
+            from: registrarOwner
+        });
+
+        await hnsRegistry.setRegistrar(registrar.address, {
+            from: rootOwner
+        });
+    });
+
+    it('owned by registrar owner', async function () {
+        var owner = await registrar.owner();
+        assert.strictEqual(owner, registrarOwner)
+    });
+
+    describe('register subnode using registrar', async function () {
+
+        it('register new subdomain on .hara', async function () {
+            var receipt = await registrar.register("0x0", haraHash, haraOwner, {from: registrarOwner});
+            var owner = await hnsRegistry.owner(haraNamehash);
+            assert.strictEqual(owner, haraOwner);
+        });
+
+        it('can not register new subdomain on dev.hara by not owner', async function () {
+            await expectRevert(registrar.register(haraNamehash, devHash, devharaOwner, {from: notOwner})
+            );
+            var owner = await hnsRegistry.owner(devharaNamehash);
+            assert.notEqual(owner, devharaOwner);
+            assert.strictEqual(owner, "0x0000000000000000000000000000000000000000");
+        });
+    });
+});

--- a/test/helpers/LogsHelper.js
+++ b/test/helpers/LogsHelper.js
@@ -266,3 +266,59 @@ module.exports.HaraTokenPrivate = {
         "type": "uint256"
     }]
 }
+
+module.exports.ContractMadeAbstract = {
+    HasGetClassTopic: "0x5e80a0839b78e29f73bb490669c9b8b77e190751a8f9569fd6a42f3a16e97a91",
+    HasGetClassAbi: []
+}
+
+module.exports.DataStore = {
+    SignatureLogTopic: "0xbb9f6a2766f43575abb11a054ffdb9a40439ea63fa517fe2cc3e8e145fc5f36b",
+    SignatureLogAbi: [{
+        "indexed": true,
+        "name": "version",
+        "type": "bytes32"
+    }, {
+        "indexed": false,
+        "name": "signature",
+        "type": "bytes"
+    }]
+}
+
+module.exports.DataProviderRelation = {
+    EndpointChangedLogTopic: "0x4111b886b9600f01e3735293a06336ba02fbb0aff7eca35ddca34d429d34119c",
+    EndpointChangedLogAbi: [{
+        "indexed": false,
+        "name": "oldEndpoint",
+        "type": "string"
+    }, {
+        "indexed": false,
+        "name": "newEndpoint",
+        "type": "string"
+    }, {
+        "indexed": true,
+        "name": "by",
+        "type": "address"
+    }]    
+}
+
+module.exports.DataFactoryProvider = {
+    RelationCreatedLogTopic: "0x47940b042ea2e2b9c22b08dfff43c2558325774a7184316e7791a584e494eae3",
+    RelationCreatedLogAbi: [{
+        "indexed": true,
+        "name": "fromAddr",
+        "type": "string"
+    }, {
+        "indexed": false,
+        "name": "fromVersion",
+        "type": "string"
+    }, {
+        "indexed": true,
+        "name": "toAddr",
+        "type": "string"
+    }, {
+        "indexed": false,
+        "name": "toVersion",
+        "type": "string"
+    }]
+}

--- a/test/multisignature/MultiSigHNS.test.js
+++ b/test/multisignature/MultiSigHNS.test.js
@@ -1,0 +1,140 @@
+const MultiSigHNS = artifacts.require("./MultiSigHNS");
+const HNS = artifacts.require("./HNSRegistry");
+
+contract("MultiSigHNS", accounts => {
+  let multisig;
+  let hns;
+
+  const owner1 = accounts[0];
+  const owner2 = accounts[1];
+  const owner3 = accounts[2];
+  const dummyResolver = accounts[3];
+  const testOwner = accounts[4];
+  const dummyRegistrar = accounts[5];
+
+  before(async function() {
+    hns = await HNS.new({
+      from: owner1
+    });
+    multisig = await MultiSigHNS.new(hns.address, { from: owner1 });
+    await hns.setRegistrar(multisig.address, {from: owner1});
+    await hns.setOwner("0x00", multisig.address, { from: owner1 });
+  });
+
+  describe(" can transact hns funciton", async function() {
+    before(async function(){
+    await multisig.submitAddOwnerTransaction(owner2, { from: owner1 });    
+    });
+
+    it("add subnodeowner", async function() {
+      var ownerBefore = await hns.owner(
+        "0x04f740db81dc36c853ab4205bddd785f46e79ccedca351fc6dfcbd8cc9a33dd6"
+      );
+      var receipt = await multisig.submitSetSubnodeOwner(
+        "0x00",
+        "0x9c22ff5f21f0b81b113e63f7db6da94fedef11b2119b4088b89664fb9a3cb658",
+        multisig.address,
+        { from: owner1 }
+      );
+      var beforeconfirmed = await hns.owner(
+        "0x04f740db81dc36c853ab4205bddd785f46e79ccedca351fc6dfcbd8cc9a33dd6"
+      );
+      assert.strictEqual(ownerBefore, beforeconfirmed);
+
+      // getting transaction id
+      var txidx = await receipt.logs[0].args.transactionId.valueOf();
+      // confirm transaction [tdxidx] by owner2
+      await multisig.confirmTransaction(txidx, { from: owner2 });
+      var ownerAfter = await hns.owner(
+        "0x04f740db81dc36c853ab4205bddd785f46e79ccedca351fc6dfcbd8cc9a33dd6"
+      );
+      assert.strictEqual(ownerAfter, multisig.address);
+      assert.notEqual(ownerBefore, ownerAfter);
+    });    
+
+    it("set resolver", async function() {
+      var resolverBefore = await hns.resolver("0x00");
+      var receipt = await multisig.submitSetResolver("0x00", dummyResolver, {
+        from: owner1
+      });
+      var beforeconfirmed = await hns.resolver("0x00");
+      assert.strictEqual(resolverBefore, beforeconfirmed);
+
+      // getting transaction id
+      var txidx = await receipt.logs[0].args.transactionId.valueOf();
+      // confirm transaction [tdxidx] by owner1
+      await multisig.confirmTransaction(txidx, { from: owner2 });
+      var resolverAfter = await hns.resolver("0x00");
+      assert.strictEqual(resolverAfter, dummyResolver);
+      assert.notEqual(resolverBefore, resolverAfter)
+    });
+
+    it("setTTL", async function() {
+      var ttlBefore = await hns.ttl(
+        "0x04f740db81dc36c853ab4205bddd785f46e79ccedca351fc6dfcbd8cc9a33dd6"
+      );
+      var receipt = await multisig.submitSetTTL(
+        "0x04f740db81dc36c853ab4205bddd785f46e79ccedca351fc6dfcbd8cc9a33dd6",
+        1,
+        { from: owner1 }
+      );
+      var beforeconfirmed = await hns.ttl(
+        "0x04f740db81dc36c853ab4205bddd785f46e79ccedca351fc6dfcbd8cc9a33dd6"
+      );
+      assert.strictEqual(ttlBefore.toString(), beforeconfirmed.toString());
+
+      // getting transaction id
+      var txidx = await receipt.logs[0].args.transactionId.valueOf();
+      // confirm transaction [tdxidx] by owner2
+      await multisig.confirmTransaction(txidx, { from: owner2 });
+      var ttlAfter = await hns.ttl(
+        "0x04f740db81dc36c853ab4205bddd785f46e79ccedca351fc6dfcbd8cc9a33dd6"
+      );
+      assert.strictEqual(ttlAfter.toString(), "1");
+      assert.notEqual(ttlBefore, ttlAfter);
+    });
+
+    it("set registrar", async function() {
+      var registrarBefore = await hns.activeRegistrar();
+      var receipt = await multisig.submitSetRegistrar(dummyRegistrar, {
+        from: owner2
+      });
+      var beforeconfirmed = await hns.activeRegistrar();
+      assert.strictEqual(registrarBefore, beforeconfirmed);
+
+      // getting transaction id
+      var txidx = await receipt.logs[0].args.transactionId.valueOf();
+      // confirm transaction [tdxidx] by owner1
+      await multisig.confirmTransaction(txidx, { from: owner1 });
+      var registrarAfter = await hns.activeRegistrar();
+      assert.strictEqual(registrarAfter, dummyRegistrar);
+      assert.notEqual(registrarBefore, registrarAfter)
+    });
+
+    it("setowner", async function() {
+      var ownerBefore = await hns.owner(
+        "0x04f740db81dc36c853ab4205bddd785f46e79ccedca351fc6dfcbd8cc9a33dd6"
+      );
+      var receipt = await multisig.submitSetOwner(
+        "0x04f740db81dc36c853ab4205bddd785f46e79ccedca351fc6dfcbd8cc9a33dd6",
+        testOwner,
+        { from: owner1 }
+      );
+      var beforeconfirmed = await hns.owner(
+        "0x04f740db81dc36c853ab4205bddd785f46e79ccedca351fc6dfcbd8cc9a33dd6"
+      );
+      assert.strictEqual(ownerBefore, beforeconfirmed);
+
+      // getting transaction id
+      var txidx = await receipt.logs[0].args.transactionId.valueOf();
+      // confirm transaction [tdxidx] by owner2
+      await multisig.confirmTransaction(txidx, { from: owner2 });
+      var ownerAfter = await hns.owner(
+        "0x04f740db81dc36c853ab4205bddd785f46e79ccedca351fc6dfcbd8cc9a33dd6"
+      );
+      assert.strictEqual(ownerAfter, testOwner);
+      assert.notEqual(ownerBefore, ownerAfter);
+    });
+
+  });
+});

--- a/test/multisignature/MultiSignature.test.js
+++ b/test/multisignature/MultiSignature.test.js
@@ -1,0 +1,290 @@
+const expectRevert = require("./../helpers/expectRevert");
+
+const MultiSigHNS = artifacts.require("./MultiSigHNS");
+const HNS = artifacts.require("./HNSRegistry");
+
+contract("MultiSigHNS", accounts => {
+  let multisig;
+  let hns;
+  let executedTx;
+
+  const owner1 = accounts[0];
+  const owner2 = accounts[1];
+  const owner3 = accounts[2];
+  const dummyResolver = accounts[3];
+  const testOwner = accounts[4];
+  const dummyRegistrar = accounts[5];
+
+  before(async function() {
+    hns = await HNS.new({
+      from: owner1
+    });
+    multisig = await MultiSigHNS.new(hns.address, { from: owner1 });
+  });
+
+  it("has 1 owner and the owner is the deployer", async function() {
+    const owners = await multisig.getOwners();
+    assert.strictEqual(owners[0], owner1);
+    assert.strictEqual(owners.length, 1);
+  });
+
+  it("has 1 required", async function() {
+    const req = await multisig.required();
+    assert.strictEqual(req.valueOf().toString(), "1");
+  });
+
+  // add another owner -> requirement -> 2
+  describe("check owner and requirement functions", async function() {
+    // add 2 more owners
+    before(async function() {
+      await multisig.submitAddOwnerTransaction(owner2, { from: owner1 });
+      var addOwner = await multisig.submitAddOwnerTransaction(owner3, {
+        from: owner1
+      });
+      await multisig.confirmTransaction(
+        addOwner.logs[0].args.transactionId.toNumber(),
+        { from: owner2 }
+      );
+    });
+
+    // check owner is 3 after add 2 owners
+    it("has 3 owner ", async function() {
+      const allOwner = await multisig.getOwners();
+      assert.strictEqual(allOwner[0], owner1);
+      assert.strictEqual(allOwner[1], owner2);
+      assert.strictEqual(allOwner[2], owner3);
+      assert.strictEqual(allOwner.length, 3);
+    });
+
+    // remove 1 owner, requirement must be still 2
+    it("remove owner3", async function() {
+      var removeOwner = await multisig.submitRemoveOwnerTransaction(owner3, {
+        from: owner1
+      });
+      await multisig.confirmTransaction(
+        removeOwner.logs[0].args.transactionId.toNumber(),
+        { from: owner2 }
+      );
+      const allOwner = await multisig.getOwners();
+      assert.strictEqual(allOwner[0], owner1);
+      assert.strictEqual(allOwner[1], owner2);
+      assert.notEqual(allOwner[2], owner3);
+      assert.strictEqual(allOwner.length, 2);
+
+      const reqEnd1 = await multisig.required();
+      assert.strictEqual(reqEnd1.valueOf().toString(), "2");
+    });
+
+    it("replace owner", async function() {
+      var removeOwner2 = await multisig.replaceOwner(owner2, owner3, {
+        from: owner1
+      });
+      const allOwner = await multisig.getOwners();
+      assert.strictEqual(allOwner[0], owner1);
+      assert.strictEqual(allOwner[1], owner3);
+      assert.notEqual(allOwner[2], owner2);
+      assert.strictEqual(allOwner.length, 2);
+    });
+
+
+    // make requirement to 1 by remove 1 owner
+    it("change requirement to 1", async function() {
+      var removeOwner2 = await multisig.submitRemoveOwnerTransaction(owner3, {
+        from: owner1
+      });
+
+      await multisig.confirmTransaction(
+        removeOwner2.logs[0].args.transactionId.toNumber(),
+        { from: owner3 }
+      );
+      executedTx = removeOwner2.logs[0].args.transactionId.toNumber();
+      const reqEnd2 = await multisig.required();
+      assert.strictEqual(reqEnd2.valueOf().toString(), "1");
+    });
+  });
+
+  describe(" can check confirmations", async function() {
+      var txid;
+    before(async function(){
+        await hns.setRegistrar(multisig.address, {from: owner1});
+        await multisig.submitAddOwnerTransaction(owner2, { from: owner1 });    
+        txid = await multisig.submitSetSubnodeOwner(
+            "0x00",
+            "0x9c22ff5f21f0b81b113e63f7db6da94fedef11b2119b4088b89664fb9a3cb658",
+            multisig.address,
+            { from: owner1 }
+          );
+    });
+
+    it("check who confirms transaction", async function() {
+        var whoConfirmed = await multisig.getConfirmations(txid.logs[0].args.transactionId.toNumber());
+        assert.strictEqual(whoConfirmed.length, 1);
+    });    
+    it("check total confirmation of transaction", async function() {
+        var totalConfirmations = await multisig.getConfirmationCount(txid.logs[0].args.transactionId.toNumber());
+        assert.strictEqual(totalConfirmations.toString(), "1")
+    });    
+
+  });
+
+  describe("modify transaction", async function() {
+      var txid;
+    before(async function(){
+        txid = await multisig.submitSetSubnodeOwner(
+            "0x00",
+            "0xadcfd56a06bafd82aac6043a83ba0191c0253d55c60a6a8ee15f1d5e7441d421",
+            multisig.address,
+            { from: owner1 }
+          );
+    });
+
+    it("can revoke confirmation", async function() {
+        var totalBefore = await multisig.getConfirmationCount(txid.logs[0].args.transactionId.toNumber());
+        var revoke = await multisig.revokeConfirmation(txid.logs[0].args.transactionId.toNumber(), {from:owner1});
+        var totalAfter = await multisig.getConfirmationCount(txid.logs[0].args.transactionId.toNumber());
+        assert.strictEqual(totalAfter.toString(), "0");
+        assert.notEqual(totalBefore.toString(), totalAfter.toString());
+    });        
+  });
+
+  describe("error test", async function() {
+    var txid;
+  before(async function(){
+      txid = await multisig.submitSetSubnodeOwner(
+          "0x00",
+          "0xadcfd56a06bafd82aac6043a83ba0191c0253d55c60a6a8ee15f1d5e7441d421",
+          multisig.address,
+          { from: owner1 }
+        );
+  });
+
+  it("can not confirm if transaction not exists", async function() {
+      await expectRevert(
+        multisig.confirmTransaction("2019", { from: owner2 })
+      );
+  }); 
+  it("can not revoke if transaction executed", async function() {
+    await expectRevert(
+      multisig.revokeConfirmation(executedTx, { from: owner2 })
+    );
+});       
+});
+
+//   describe(" can transact hns funciton", async function() {
+//     // let hart;
+//     before(async function(){
+//     await multisig.submitAddOwnerTransaction(owner2, { from: owner1 });    
+//     });
+
+//     it("add subnodeowner", async function() {
+//       var ownerBefore = await hns.owner(
+//         "0x04f740db81dc36c853ab4205bddd785f46e79ccedca351fc6dfcbd8cc9a33dd6"
+//       );
+//       var receipt = await multisig.submitSetSubnodeOwner(
+//         "0x00",
+//         "0x9c22ff5f21f0b81b113e63f7db6da94fedef11b2119b4088b89664fb9a3cb658",
+//         multisig.address,
+//         { from: owner1 }
+//       );
+//       var beforeconfirmed = await hns.owner(
+//         "0x04f740db81dc36c853ab4205bddd785f46e79ccedca351fc6dfcbd8cc9a33dd6"
+//       );
+//       assert.strictEqual(ownerBefore, beforeconfirmed);
+
+//       // getting transaction id
+//       var txidx = await receipt.logs[0].args.transactionId.valueOf();
+//       // confirm transaction [tdxidx] by owner2
+//       await multisig.confirmTransaction(txidx, { from: owner2 });
+//       var ownerAfter = await hns.owner(
+//         "0x04f740db81dc36c853ab4205bddd785f46e79ccedca351fc6dfcbd8cc9a33dd6"
+//       );
+//       assert.strictEqual(ownerAfter, multisig.address);
+//       assert.notEqual(ownerBefore, ownerAfter);
+//     });    
+
+//     it("set resolver", async function() {
+//       var resolverBefore = await hns.resolver("0x00");
+//       var receipt = await multisig.submitSetResolver("0x00", dummyResolver, {
+//         from: owner1
+//       });
+//       var beforeconfirmed = await hns.resolver("0x00");
+//       assert.strictEqual(resolverBefore, beforeconfirmed);
+
+//       // getting transaction id
+//       var txidx = await receipt.logs[0].args.transactionId.valueOf();
+//       // confirm transaction [tdxidx] by owner1
+//       await multisig.confirmTransaction(txidx, { from: owner2 });
+//       var resolverAfter = await hns.resolver("0x00");
+//       assert.strictEqual(resolverAfter, dummyResolver);
+//       assert.notEqual(resolverBefore, resolverAfter)
+//     });
+
+//     it("setTTL", async function() {
+//       var ttlBefore = await hns.ttl(
+//         "0x04f740db81dc36c853ab4205bddd785f46e79ccedca351fc6dfcbd8cc9a33dd6"
+//       );
+//       var receipt = await multisig.submitSetTTL(
+//         "0x04f740db81dc36c853ab4205bddd785f46e79ccedca351fc6dfcbd8cc9a33dd6",
+//         1,
+//         { from: owner1 }
+//       );
+//       var beforeconfirmed = await hns.ttl(
+//         "0x04f740db81dc36c853ab4205bddd785f46e79ccedca351fc6dfcbd8cc9a33dd6"
+//       );
+//       assert.strictEqual(ttlBefore.toString(), beforeconfirmed.toString());
+
+//       // getting transaction id
+//       var txidx = await receipt.logs[0].args.transactionId.valueOf();
+//       // confirm transaction [tdxidx] by owner2
+//       await multisig.confirmTransaction(txidx, { from: owner2 });
+//       var ttlAfter = await hns.ttl(
+//         "0x04f740db81dc36c853ab4205bddd785f46e79ccedca351fc6dfcbd8cc9a33dd6"
+//       );
+//       assert.strictEqual(ttlAfter.toString(), "1");
+//       assert.notEqual(ttlBefore, ttlAfter);
+//     });
+
+//     it("set registrar", async function() {
+//       var registrarBefore = await hns.activeRegistrar();
+//       var receipt = await multisig.submitSetRegistrar(dummyRegistrar, {
+//         from: owner2
+//       });
+//       var beforeconfirmed = await hns.activeRegistrar();
+//       assert.strictEqual(registrarBefore, beforeconfirmed);
+
+//       // getting transaction id
+//       var txidx = await receipt.logs[0].args.transactionId.valueOf();
+//       // confirm transaction [tdxidx] by owner1
+//       await multisig.confirmTransaction(txidx, { from: owner1 });
+//       var registrarAfter = await hns.activeRegistrar();
+//       assert.strictEqual(registrarAfter, dummyRegistrar);
+//       assert.notEqual(registrarBefore, registrarAfter)
+//     });
+
+//     it("setowner", async function() {
+//       var ownerBefore = await hns.owner(
+//         "0x04f740db81dc36c853ab4205bddd785f46e79ccedca351fc6dfcbd8cc9a33dd6"
+//       );
+//       var receipt = await multisig.submitSetOwner(
+//         "0x04f740db81dc36c853ab4205bddd785f46e79ccedca351fc6dfcbd8cc9a33dd6",
+//         testOwner,
+//         { from: owner1 }
+//       );
+//       var beforeconfirmed = await hns.owner(
+//         "0x04f740db81dc36c853ab4205bddd785f46e79ccedca351fc6dfcbd8cc9a33dd6"
+//       );
+//       assert.strictEqual(ownerBefore, beforeconfirmed);
+
+//       // getting transaction id
+//       var txidx = await receipt.logs[0].args.transactionId.valueOf();
+//       // confirm transaction [tdxidx] by owner2
+//       await multisig.confirmTransaction(txidx, { from: owner2 });
+//       var ownerAfter = await hns.owner(
+//         "0x04f740db81dc36c853ab4205bddd785f46e79ccedca351fc6dfcbd8cc9a33dd6"
+//       );
+//       assert.strictEqual(ownerAfter, testOwner);
+//       assert.notEqual(ownerBefore, ownerAfter);
+//     });
+
+//   });
+});

--- a/test/use-case/attest.test.js
+++ b/test/use-case/attest.test.js
@@ -1,0 +1,735 @@
+const DataFactoryRegistryContract = artifacts.require("DataFactoryRegistry");
+const DataFactoryContract = artifacts.require("DataFactory");
+const DataStoreContract = artifacts.require("DataStore");
+const HaraToken = artifacts.require("HaraTokenPrivate");
+const DataProviderNull = artifacts.require("DataProviderNull");
+const DataFactoryProvider = artifacts.require("DataFactoryProvider"); // the wina
+const DataProviderRelation = artifacts.require("DataProviderRelation");
+const Attest = artifacts.require("AttestContract");
+
+const expectRevert = require("./../helpers/expectRevert");
+const encoderDecoder = require("./../helpers/encoderDecoder");
+const logsDetail = require("./../helpers/LogsHelper");
+
+contract("Use case for attestation", accounts => {
+  let datafactoryregistry;
+  let datafactory;
+  let datastoreA;
+  let datastoreB;
+  let datastoreC;
+  let datastoreD;
+  let datastoreE;
+  let datastoreRelation;
+  let hart;
+  let dataprovidernull;
+  let dataproviderrelation;
+  let initHartAddress;
+  let attestContract;
+  let datafactoryprovider;
+
+  const initSignature =
+    "0x430dec04b9ebe807ce8fb9b0d025861c13f5e36f226c12469ff6f89fb217fa9f";
+  const initSignatureFunc = "keccak";
+
+  const initVersion = web3.utils.toHex(12).padEnd(66, "0");
+  const initTopic1 = web3.utils.fromAscii("ktp").padEnd(66, "0"); //bytes32("lahan")
+  const initTopic2 = web3.utils.fromAscii("lahan").padEnd(66, "0"); //bytes32("ktp")
+  const initValue = web3.utils.fromAscii("ok").padEnd(66, "0"); //bytes32("ok")
+  const initExpiredTime = new Date("Wed, 8 May 2019 13:30:00").getTime();
+
+  const contractOwner = accounts[0];
+  const dataOwner1 = accounts[1];
+  const dataOwner2 = accounts[2];
+  const notOwner = accounts[3];
+  const hara = accounts[4];
+
+  const DataCreationLogTopic = logsDetail.DataFactory.DataCreationLogTopic;
+  const DataCreationLogAbi = logsDetail.DataFactory.DataCreationLogAbi;
+
+  const SignatureLogTopic =
+    logsDetail.DataStore.SignatureLogTopic;
+  const SignatureLogAbi =
+    logsDetail.DataStore.SignatureLogAbi;
+
+  const EndpointChangedLogTopic =
+    logsDetail.DataProviderRelation.EndpointChangedLogTopic;
+  const EndpointChangedLogAbi =
+    logsDetail.DataProviderRelation.EndpointChangedLogAbi;
+
+    const RelationCreatedLogTopic =
+    logsDetail.DataFactoryProvider.RelationCreatedLogTopic;
+  const RelationCreatedLogAbi =
+    logsDetail.DataFactoryProvider.RelationCreatedLogAbi;
+
+  before(async () => {
+    // deploy hara token contract
+    var haratokenContract = new web3.eth.Contract(HaraToken.abi);
+    hart = await haratokenContract
+      .deploy({
+        data: HaraToken.bytecode
+      })
+      .send({
+        from: contractOwner,
+        gas: 4700000
+      });
+    initHartAddress = hart.options.address;
+
+    await hart.methods.mint(contractOwner, web3.utils.toWei("1000")).send({
+      from: contractOwner
+    });
+
+    // deploy data factory
+    datafactory = await DataFactoryContract.new(initHartAddress, {
+      from: contractOwner
+    });
+
+    // deploy contract factory registry
+    datafactoryregistry = await DataFactoryRegistryContract.new(
+      datafactory.address,
+      {
+        from: contractOwner
+      }
+    );
+
+    // set allowed address to store data at data factory registry contract
+    await datafactoryregistry.addAllowedAddress(hara, { from: contractOwner });
+
+    // deploy data provider null
+    dataprovidernull = await DataProviderNull.new({
+      from: contractOwner
+    });
+
+    // deploy data provider relation
+    dataproviderrelation = await DataProviderRelation.new({
+      from: contractOwner
+    });
+
+    // deploy attest contract
+    attestContract = await Attest.new({
+      from: contractOwner
+    });
+  });
+
+  describe("Upload: data A, B, C, owned by owner1", async () => {
+    it("create data A with owner 1", async () => {
+      var receipt = await datafactoryregistry.storeData(
+        dataOwner1,
+        dataprovidernull.address,
+        web3.utils.asciiToHex(initSignature),
+        web3.utils.asciiToHex(initSignatureFunc),
+        {
+          from: hara
+        }
+      );
+      const logs = receipt.receipt.rawLogs;
+      const DataCreationLog = encoderDecoder.decodeLogsByTopic(
+        DataCreationLogTopic,
+        DataCreationLogAbi,
+        logs
+      )[0];
+      datastoreA = await DataStoreContract.at(
+        DataCreationLog.contractDataAddress
+      );
+      const ownerData = await datastoreA.owner();
+      assert.strictEqual(ownerData, dataOwner1);
+      const sig = await datastoreA.getSignature(web3.utils.keccak256("0"));
+      assert.strictEqual(sig, web3.utils.asciiToHex(initSignature));
+      const sigFunc = await datastoreA.getSignatureFunction();
+      assert.strictEqual(sigFunc, web3.utils.asciiToHex(initSignatureFunc));
+    });
+
+    it("create data B with owner 1", async () => {
+      var receipt = await datafactoryregistry.storeData(
+        dataOwner1,
+        dataprovidernull.address,
+        web3.utils.asciiToHex(initSignature),
+        web3.utils.asciiToHex(initSignatureFunc),
+        {
+          from: hara
+        }
+      );
+      const logs = receipt.receipt.rawLogs;
+      const DataCreationLog = encoderDecoder.decodeLogsByTopic(
+        DataCreationLogTopic,
+        DataCreationLogAbi,
+        logs
+      )[0];
+      datastoreB = await DataStoreContract.at(
+        DataCreationLog.contractDataAddress
+      );
+      const ownerData = await datastoreB.owner();
+      assert.strictEqual(ownerData, dataOwner1);
+      const sig = await datastoreB.getSignature(web3.utils.keccak256("0"));
+      assert.strictEqual(sig, web3.utils.asciiToHex(initSignature));
+      const sigFunc = await datastoreB.getSignatureFunction();
+      assert.strictEqual(sigFunc, web3.utils.asciiToHex(initSignatureFunc));
+    });
+
+    it("create data C with owner 1", async () => {
+      var receipt = await datafactoryregistry.storeData(
+        dataOwner1,
+        dataprovidernull.address,
+        web3.utils.asciiToHex(initSignature),
+        web3.utils.asciiToHex(initSignatureFunc),
+        {
+          from: hara
+        }
+      );
+      const logs = receipt.receipt.rawLogs;
+      const DataCreationLog = encoderDecoder.decodeLogsByTopic(
+        DataCreationLogTopic,
+        DataCreationLogAbi,
+        logs
+      )[0];
+      datastoreC = await DataStoreContract.at(
+        DataCreationLog.contractDataAddress
+      );
+      const ownerData = await datastoreC.owner();
+      assert.strictEqual(ownerData, dataOwner1);
+      const sig = await datastoreC.getSignature(web3.utils.keccak256("0"));
+      assert.strictEqual(sig, web3.utils.asciiToHex(initSignature));
+      const sigFunc = await datastoreC.getSignatureFunction();
+      assert.strictEqual(sigFunc, web3.utils.asciiToHex(initSignatureFunc));
+    });
+  });
+  describe("Upload: data D, E owned by owner2", async () => {
+    it("create data D with owner 2", async () => {
+      var receipt = await datafactoryregistry.storeData(
+        dataOwner2,
+        dataprovidernull.address,
+        web3.utils.asciiToHex(initSignature),
+        web3.utils.asciiToHex(initSignatureFunc),
+        {
+          from: hara
+        }
+      );
+      const logs = receipt.receipt.rawLogs;
+      const DataCreationLog = encoderDecoder.decodeLogsByTopic(
+        DataCreationLogTopic,
+        DataCreationLogAbi,
+        logs
+      )[0];
+      datastoreD = await DataStoreContract.at(
+        DataCreationLog.contractDataAddress
+      );
+      const ownerData = await datastoreD.owner();
+      assert.strictEqual(ownerData, dataOwner2);
+      const sig = await datastoreD.getSignature(web3.utils.keccak256("0"));
+      assert.strictEqual(sig, web3.utils.asciiToHex(initSignature));
+      const sigFunc = await datastoreD.getSignatureFunction();
+      assert.strictEqual(sigFunc, web3.utils.asciiToHex(initSignatureFunc));
+    });
+
+    it("create data E with owner 2", async () => {
+      var receipt = await datafactoryregistry.storeData(
+        dataOwner2,
+        dataprovidernull.address,
+        web3.utils.asciiToHex(initSignature),
+        web3.utils.asciiToHex(initSignatureFunc),
+        {
+          from: hara
+        }
+      );
+      const logs = receipt.receipt.rawLogs;
+      const DataCreationLog = encoderDecoder.decodeLogsByTopic(
+        DataCreationLogTopic,
+        DataCreationLogAbi,
+        logs
+      )[0];
+      datastoreE = await DataStoreContract.at(
+        DataCreationLog.contractDataAddress
+      );
+      const ownerData = await datastoreE.owner();
+      assert.strictEqual(ownerData, dataOwner2);
+      const sig = await datastoreE.getSignature(web3.utils.keccak256("0"));
+      assert.strictEqual(sig, web3.utils.asciiToHex(initSignature));
+      const sigFunc = await datastoreE.getSignatureFunction();
+      assert.strictEqual(sigFunc, web3.utils.asciiToHex(initSignatureFunc));
+    });
+  });
+  describe("Upload: data A, B, C, D, E have owner", async () => {
+    it("data A, C owned by dataOwner1", async () => {
+      const ownerDataA = await datastoreA.owner();
+      const ownerDataC = await datastoreC.owner();
+      assert.strictEqual(ownerDataA, ownerDataC);
+      assert.strictEqual(ownerDataA, dataOwner1);
+      assert.strictEqual(ownerDataC, dataOwner1);
+      assert.notStrictEqual(ownerDataA, dataOwner2);
+      assert.notStrictEqual(ownerDataC, dataOwner2);
+    });
+
+    it("data A, C not owned by dataOwner1", async () => {
+      const ownerDataA = await datastoreA.owner();
+      const ownerDataC = await datastoreC.owner();
+      assert.strictEqual(ownerDataA, ownerDataC);
+      assert.strictEqual(ownerDataA, dataOwner1);
+      assert.strictEqual(ownerDataC, dataOwner1);
+      assert.notStrictEqual(ownerDataA, dataOwner2);
+      assert.notStrictEqual(ownerDataC, dataOwner2);
+    });
+  });
+  describe("Attest: can attest data A by data owner 1", async () => {
+    let AttestActionLog;
+    let WhoAttestLog;
+    let AttestLog;
+    let concatedBytes;
+    let encryptedBytes;
+    before(async () => {
+      var receipt = await attestContract.attest(
+        initVersion,
+        datastoreA.address,
+        initTopic1,
+        initValue,
+        initExpiredTime,
+        { from: dataOwner1 }
+      );
+      AttestActionLog = receipt.receipt.logs[1].args;
+      WhoAttestLog = receipt.receipt.logs[2].args;
+      AttestLog = receipt.receipt.logs[3].args;
+      concatedBytes =
+        "0x" +
+        web3.utils
+          .numberToHex(initVersion)
+          .slice(2)
+          .padStart(16, "0") +
+        datastoreA.address.slice(2).toLowerCase() +
+        initTopic1.slice(2) +
+        dataOwner1.slice(2).toLowerCase();
+      encryptedBytes = web3.utils.keccak256(concatedBytes);
+    });
+
+    it("AttestActionLog is working", async () => {
+      assert.strictEqual(AttestActionLog.encryptedBytes, encryptedBytes);
+      assert.strictEqual(AttestActionLog.version, initVersion);
+      assert.strictEqual(AttestActionLog.itemAddress, datastoreA.address);
+      assert.strictEqual(AttestActionLog.topic, initTopic1);
+      assert.strictEqual(AttestActionLog.attestor, dataOwner1);
+      assert.strictEqual(AttestActionLog.value, initValue);
+      assert.strictEqual(
+        parseInt(AttestActionLog.expiredTime),
+        initExpiredTime
+      );
+    });
+
+    it("WhoAttestLog is working", async function() {
+      assert.strictEqual(WhoAttestLog.encryptedBytes, encryptedBytes);
+      assert.strictEqual(WhoAttestLog.version, initVersion);
+      assert.strictEqual(WhoAttestLog.itemAddress, datastoreA.address);
+      assert.strictEqual(WhoAttestLog.topic, initTopic1);
+      assert.strictEqual(WhoAttestLog.attestor, dataOwner1);
+    });
+
+    it("AttestLog is working", async function() {
+      assert.strictEqual(AttestLog.encryptedBytes, encryptedBytes);
+      assert.strictEqual(AttestLog.version, initVersion);
+      assert.strictEqual(AttestLog.itemAddress, datastoreA.address);
+      assert.strictEqual(AttestLog.topic, initTopic1);
+      assert.strictEqual(AttestLog.attestor, dataOwner1);
+    });
+  });
+  describe("Attest: can attest data A by data owner 2", async () => {
+    let AttestActionLog;
+    let WhoAttestLog;
+    let AttestLog;
+    let concatedBytes;
+    let encryptedBytes;
+    before(async () => {
+      var receipt = await attestContract.attest(
+        initVersion,
+        datastoreA.address,
+        initTopic2,
+        initValue,
+        initExpiredTime,
+        { from: dataOwner2 }
+      );
+
+      AttestActionLog = receipt.receipt.logs[1].args;
+      WhoAttestLog = receipt.receipt.logs[2].args;
+      AttestLog = receipt.receipt.logs[3].args;
+      concatedBytes =
+        "0x" +
+        web3.utils
+          .numberToHex(initVersion)
+          .slice(2)
+          .padStart(16, "0") +
+        datastoreA.address.slice(2).toLowerCase() +
+        initTopic2.slice(2) +
+        dataOwner2.slice(2).toLowerCase();
+      encryptedBytes = web3.utils.keccak256(concatedBytes);
+    });
+
+    it("AttestActionLog is working", async function() {
+      assert.strictEqual(AttestActionLog.encryptedBytes, encryptedBytes);
+      assert.strictEqual(AttestActionLog.version, initVersion);
+      assert.strictEqual(AttestActionLog.itemAddress, datastoreA.address);
+      assert.strictEqual(AttestActionLog.topic, initTopic2);
+      assert.strictEqual(AttestActionLog.attestor, dataOwner2);
+      assert.strictEqual(AttestActionLog.value, initValue);
+      assert.strictEqual(
+        parseInt(AttestActionLog.expiredTime),
+        initExpiredTime
+      );
+    });
+
+    it("WhoAttestLog is working", async function() {
+      assert.strictEqual(WhoAttestLog.encryptedBytes, encryptedBytes);
+      assert.strictEqual(WhoAttestLog.version, initVersion);
+      assert.strictEqual(WhoAttestLog.itemAddress, datastoreA.address);
+      assert.strictEqual(WhoAttestLog.topic, initTopic2);
+      assert.strictEqual(WhoAttestLog.attestor, dataOwner2);
+    });
+
+    it("AttestLog is working", async function() {
+      assert.strictEqual(AttestLog.encryptedBytes, encryptedBytes);
+      assert.strictEqual(AttestLog.version, initVersion);
+      assert.strictEqual(AttestLog.itemAddress, datastoreA.address);
+      assert.strictEqual(AttestLog.topic, initTopic2);
+      assert.strictEqual(AttestLog.attestor, dataOwner2);
+    });
+  });
+
+  describe("Attest: get attestation details", async () => {
+    it("can get details of data A attestation by data owner 1", async () => {
+      var value = await attestContract.getValue(
+        initVersion,
+        datastoreA.address,
+        initTopic1,
+        dataOwner1
+      );
+      var expiredTime = await attestContract.getExpiredTime(
+        initVersion,
+        datastoreA.address,
+        initTopic1,
+        dataOwner1
+      );
+      assert.strictEqual(value, initValue);
+      assert.strictEqual(parseInt(expiredTime), initExpiredTime);
+    });
+
+    it("can get details of data A attestation by data owner 2", async () => {
+      var value = await attestContract.getValue(
+        initVersion,
+        datastoreA.address,
+        initTopic2,
+        dataOwner2
+      );
+      var expiredTime = await attestContract.getExpiredTime(
+        initVersion,
+        datastoreA.address,
+        initTopic2,
+        dataOwner2
+      );
+      assert.strictEqual(value, initValue);
+      assert.strictEqual(parseInt(expiredTime), initExpiredTime);
+    });
+  });
+
+  describe("Relation: create relation for two data", async () => {
+    before(async () => {
+      // create data store relation
+      var receipt = await datafactoryregistry.storeData(
+        hara,
+        dataproviderrelation.address,
+        web3.utils.asciiToHex("relation"),
+        web3.utils.asciiToHex(initSignatureFunc),
+        {
+          from: hara
+        }
+      );
+      const logs = receipt.receipt.rawLogs;
+      const DataCreationLog = encoderDecoder.decodeLogsByTopic(
+        DataCreationLogTopic,
+        DataCreationLogAbi,
+        logs
+      )[0];
+      datastoreRelation = await DataStoreContract.at(
+        DataCreationLog.contractDataAddress
+      );
+
+      // deploy data factory privider (the wina)
+      datafactoryprovider = await DataFactoryProvider.new(
+        datastoreRelation.address,
+        dataproviderrelation.address, {
+        from: hara
+      });
+    // set datafactoryprovider as editor
+    await datastoreRelation.setEditor(datafactoryprovider.address, {from: hara});
+
+    // set provider proxy
+    await dataproviderrelation.setProxyAddress(datafactoryprovider.address, {from: contractOwner});
+
+    });
+    it("connect data A to B", async () => {
+      var receipt = await datafactoryprovider.addNewVersion(
+        web3.utils.soliditySha3({t:'address',v:datastoreA.address}, 
+          {t:'bytes32',v:web3.utils.keccak256("0")}, {t:'address',v:datastoreB.address}, {t:'bytes32',v:web3.utils.keccak256("0")}), // version
+        web3.utils.keccak256(datastoreA + "*0*" + datastoreB + "*0"), // signature
+        // web3.utils.soliditySha3({t:'string', v:datastoreA.address}, {t:'string',v:web3.utils.keccak256("0")}), // bytes256(from addr + version)
+        // datastoreB.address + "2", // to
+        datastoreA.address, // fromAddr
+        "0", // fromVersion
+        datastoreB.address.toString(), //toAddr
+        "2", //toVersion
+        {from: hara }
+      );
+      const logs = receipt.receipt.rawLogs;
+      const EndpointChangedLog = encoderDecoder.decodeLogsByTopic(
+        EndpointChangedLogTopic,
+        EndpointChangedLogAbi,
+        logs
+      )[0];
+      const SignatureLog = encoderDecoder.decodeLogsByTopic(
+        SignatureLogTopic,
+        SignatureLogAbi,
+        logs
+      )[0];
+      const RelationCreatedLog = encoderDecoder.decodeLogsByTopic(
+        RelationCreatedLogTopic,
+        RelationCreatedLogAbi,
+        logs
+      )[0];
+      assert.strictEqual(EndpointChangedLog.newEndpoint, datastoreB.address + "2");
+      assert.strictEqual(EndpointChangedLog.by, datafactoryprovider.address);
+      assert.strictEqual(SignatureLog.version,  web3.utils.soliditySha3({t:'address',v:datastoreA.address},{t:'bytes32',v:web3.utils.keccak256("0")}, {t:'address',v:datastoreB.address}, {t:'bytes32',v:web3.utils.keccak256("0")}));
+      assert.strictEqual(SignatureLog.signature, web3.utils.keccak256(datastoreA + "*0*" + datastoreB + "*0"));
+      assert.strictEqual(RelationCreatedLog.fromAddr, web3.utils.soliditySha3({t:'string',v:datastoreA.address}));
+      assert.strictEqual(RelationCreatedLog.fromVersion, "0");
+      assert.strictEqual(RelationCreatedLog.toAddr, web3.utils.soliditySha3({t:'string',v:datastoreB.address}));
+      assert.strictEqual(RelationCreatedLog.toVersion, "2");
+    });
+    it("connect data A to C", async () => {
+      var receipt = await datafactoryprovider.addNewVersion(
+        web3.utils.soliditySha3({t:'address',v:datastoreA.address}, 
+          {t:'bytes32',v:web3.utils.keccak256("0")}, {t:'address',v:datastoreC.address}, {t:'bytes32',v:web3.utils.keccak256("0")}), // version
+        web3.utils.keccak256(datastoreA + "*0*" + datastoreC + "*0"), // signature
+        // web3.utils.soliditySha3({t:'string', v:datastoreA.address}, {t:'string',v:web3.utils.keccak256("0")}), // bytes256(from addr + version)
+        // datastoreC.address + "2", // to
+        datastoreA.address,
+        "0",
+        datastoreC.address,
+        "2",
+        {from: hara }
+      );
+      const logs = receipt.receipt.rawLogs;
+      const EndpointChangedLog = encoderDecoder.decodeLogsByTopic(
+        EndpointChangedLogTopic,
+        EndpointChangedLogAbi,
+        logs
+      )[0];
+      const SignatureLog = encoderDecoder.decodeLogsByTopic(
+        SignatureLogTopic,
+        SignatureLogAbi,
+        logs
+      )[0];
+      const RelationCreatedLog = encoderDecoder.decodeLogsByTopic(
+        RelationCreatedLogTopic,
+        RelationCreatedLogAbi,
+        logs
+      )[0];
+      assert.strictEqual(EndpointChangedLog.newEndpoint, datastoreC.address + "2");
+      assert.strictEqual(EndpointChangedLog.by,  datafactoryprovider.address);
+      assert.strictEqual(SignatureLog.version,  web3.utils.soliditySha3({t:'address',v:datastoreA.address}, 
+      {t:'bytes32',v:web3.utils.keccak256("0")}, {t:'address',v:datastoreC.address}, {t:'bytes32',v:web3.utils.keccak256("0")}));
+      assert.strictEqual(SignatureLog.signature, web3.utils.keccak256(datastoreA + "*0*" + datastoreB + "*0"));
+      assert.strictEqual(RelationCreatedLog.fromAddr, web3.utils.soliditySha3({t:'string',v:datastoreA.address}));
+      assert.strictEqual(RelationCreatedLog.fromVersion, "0");
+      assert.strictEqual(RelationCreatedLog.toAddr, web3.utils.soliditySha3({t:'string',v:datastoreC.address}));
+      assert.strictEqual(RelationCreatedLog.toVersion, "2");
+    });
+    it("connect data B to C", async () => {
+      var receipt = await datafactoryprovider.addNewVersion(
+        web3.utils.soliditySha3({t:'address',v:datastoreB.address}, 
+          {t:'bytes32',v:web3.utils.keccak256("0")}, {t:'address',v:datastoreC.address}, {t:'bytes32',v:web3.utils.keccak256("0")}), // version
+        web3.utils.keccak256(datastoreB + "*0*" + datastoreC + "*0"), // signature
+        // web3.utils.soliditySha3({t:'string', v:datastoreB.address}, {t:'string',v:web3.utils.keccak256("0")}), // bytes256(from addr + version)
+        // datastoreC.address + "2", // to
+        datastoreB.address,
+        "0",
+        datastoreC.address,
+        "2",
+        {from: hara }
+      );
+      const logs = receipt.receipt.rawLogs;
+      const EndpointChangedLog = encoderDecoder.decodeLogsByTopic(
+        EndpointChangedLogTopic,
+        EndpointChangedLogAbi,
+        logs
+      )[0];
+      const SignatureLog = encoderDecoder.decodeLogsByTopic(
+        SignatureLogTopic,
+        SignatureLogAbi,
+        logs
+      )[0];
+      const RelationCreatedLog = encoderDecoder.decodeLogsByTopic(
+        RelationCreatedLogTopic,
+        RelationCreatedLogAbi,
+        logs
+      )[0];
+      assert.strictEqual(EndpointChangedLog.newEndpoint, datastoreC.address + "2");
+      assert.strictEqual(EndpointChangedLog.by,  datafactoryprovider.address);
+      assert.strictEqual(SignatureLog.version,  web3.utils.soliditySha3({t:'address',v:datastoreB.address}, 
+      {t:'bytes32',v:web3.utils.keccak256("0")}, {t:'address',v:datastoreC.address}, {t:'bytes32',v:web3.utils.keccak256("0")}));
+      assert.strictEqual(SignatureLog.signature, web3.utils.keccak256(datastoreB + "*0*" + datastoreC + "*0"));
+      assert.strictEqual(RelationCreatedLog.fromAddr, web3.utils.soliditySha3({t:'string',v:datastoreB.address}));
+      assert.strictEqual(RelationCreatedLog.fromVersion, "0");
+      assert.strictEqual(RelationCreatedLog.toAddr, web3.utils.soliditySha3({t:'string',v:datastoreC.address}));
+      assert.strictEqual(RelationCreatedLog.toVersion, "2");
+      
+    });
+    it("connect data C to A", async () => {
+      var receipt = await datafactoryprovider.addNewVersion(
+        web3.utils.soliditySha3({t:'address',v:datastoreC.address}, 
+          {t:'bytes32',v:web3.utils.keccak256("0")}, {t:'address',v:datastoreA.address}, {t:'bytes32',v:web3.utils.keccak256("0")}), // version
+        web3.utils.keccak256(datastoreC + "*0*" + datastoreA + "*0"), // signature
+        // web3.utils.soliditySha3({t:'string', v:datastoreC.address}, {t:'string',v:web3.utils.keccak256("0")}), // bytes256(from addr + version)
+        // datastoreA.address + "2", // to
+        datastoreC.address,
+        "0",
+        datastoreA.address,
+        "2",
+        {from: hara }
+      );
+      const logs = receipt.receipt.rawLogs;
+      const EndpointChangedLog = encoderDecoder.decodeLogsByTopic(
+        EndpointChangedLogTopic,
+        EndpointChangedLogAbi,
+        logs
+      )[0];
+      const SignatureLog = encoderDecoder.decodeLogsByTopic(
+        SignatureLogTopic,
+        SignatureLogAbi,
+        logs
+      )[0];
+      const RelationCreatedLog = encoderDecoder.decodeLogsByTopic(
+        RelationCreatedLogTopic,
+        RelationCreatedLogAbi,
+        logs
+      )[0];
+      assert.strictEqual(EndpointChangedLog.newEndpoint, datastoreA.address + "2");
+      assert.strictEqual(EndpointChangedLog.by,  datafactoryprovider.address);
+      assert.strictEqual(SignatureLog.version,  web3.utils.soliditySha3({t:'address',v:datastoreC.address}, 
+      {t:'bytes32',v:web3.utils.keccak256("0")}, {t:'address',v:datastoreA.address}, {t:'bytes32',v:web3.utils.keccak256("0")}));
+      assert.strictEqual(SignatureLog.signature, web3.utils.keccak256(datastoreC + "*0*" + datastoreA + "*0"));
+      assert.strictEqual(RelationCreatedLog.fromAddr, web3.utils.soliditySha3({t:'string',v:datastoreC.address}));
+      assert.strictEqual(RelationCreatedLog.fromVersion, "0");
+      assert.strictEqual(RelationCreatedLog.toAddr, web3.utils.soliditySha3({t:'string',v:datastoreA.address}));
+      assert.strictEqual(RelationCreatedLog.toVersion, "2");
+    });
+  });
+
+  describe("Relation: get relations", async () => {
+    it("get all from connection of A", async () => {
+      let filterLogs = await datafactoryprovider.getPastEvents('RelationCreatedLog', {
+        topics: [RelationCreatedLogTopic, web3.utils.soliditySha3({t:'string',v:datastoreA.address}), null],
+        fromBlock: 0,
+        toBlock: 'latest'
+    })
+    assert.strictEqual(filterLogs.length, 2)
+    });
+    it("get all to connection of A", async () => {
+      let filterLogs = await datafactoryprovider.getPastEvents('RelationCreatedLog', {
+        topics: [RelationCreatedLogTopic, null, web3.utils.soliditySha3({t:'string',v:datastoreA.address})],
+        fromBlock: 0,
+        toBlock: 'latest',
+    })
+    assert.strictEqual(filterLogs.length, 1)
+    });
+    it("get all from connection of B", async () => {
+      let filterLogs = await datafactoryprovider.getPastEvents('RelationCreatedLog', {
+        topics: [RelationCreatedLogTopic, web3.utils.soliditySha3({t:'string',v:datastoreB.address}), null],
+        fromBlock: 0,
+        toBlock: 'latest'
+    })
+    assert.strictEqual(filterLogs.length, 1)
+    });
+    it("get all to connection of B", async () => {
+      let filterLogs = await datafactoryprovider.getPastEvents('RelationCreatedLog', {
+        topics: [RelationCreatedLogTopic, null, web3.utils.soliditySha3({t:'string',v:datastoreB.address})],
+        fromBlock: 0,
+        toBlock: 'latest',
+    })
+    assert.strictEqual(filterLogs.length, 1)
+    });
+    it("get all from connection of C", async () => {
+      let filterLogs = await datafactoryprovider.getPastEvents('RelationCreatedLog', {
+        // filter: {fromAddr: datastoreC.address}, 
+        fromBlock: 0,
+        toBlock: 'latest',
+        topics: [RelationCreatedLogTopic, web3.utils.soliditySha3({t:'string',v:datastoreC.address}), null],
+    })
+    assert.strictEqual(filterLogs.length, 1)
+    });
+    it("get all to connection of C", async () => {
+      let filterLogs = await datafactoryprovider.getPastEvents('RelationCreatedLog', {
+        fromBlock: 0,
+        toBlock: 'latest',
+        topics: [RelationCreatedLogTopic, null, web3.utils.soliditySha3({t:'string',v:datastoreC.address})]
+    })
+    assert.strictEqual(filterLogs.length, 2)
+    });
+  });
+
+  describe("Attest Relation: Attest relation A to B", async () => {
+    let AttestActionLog;
+    let WhoAttestLog;
+    let AttestLog;
+    let concatedBytes;
+    let encryptedBytes;
+    let version;
+    before(async () => {
+      version = web3.utils.soliditySha3({t:'address',v:datastoreA.address}, 
+          {t:'bytes32',v:web3.utils.keccak256("0")}, {t:'address',v:datastoreB.address}, {t:'bytes32',v:web3.utils.keccak256("0")});
+      var receipt = await attestContract.attest(
+        version,
+        datastoreRelation.address,
+        initTopic2,
+        initValue,
+        initExpiredTime,
+        { from: hara }
+      );
+
+      AttestActionLog = receipt.receipt.logs[1].args;
+      WhoAttestLog = receipt.receipt.logs[2].args;
+      AttestLog = receipt.receipt.logs[3].args;
+      concatedBytes =
+        "0x" +
+        web3.utils
+          .numberToHex(version)
+          .slice(2)
+          .padStart(16, "0") +
+        datastoreRelation.address.slice(2).toLowerCase() +
+        initTopic2.slice(2) +
+        hara.slice(2).toLowerCase();
+      encryptedBytes = web3.utils.keccak256(concatedBytes);
+    });
+
+    it("AttestActionLog is working", async function() {
+      assert.strictEqual(AttestActionLog.encryptedBytes, encryptedBytes);
+      assert.strictEqual(AttestActionLog.version, version);
+      assert.strictEqual(AttestActionLog.itemAddress, datastoreRelation.address);
+      assert.strictEqual(AttestActionLog.topic, initTopic2);
+      assert.strictEqual(AttestActionLog.attestor, hara);
+      assert.strictEqual(AttestActionLog.value, initValue);
+      assert.strictEqual(
+        parseInt(AttestActionLog.expiredTime),
+        initExpiredTime
+      );
+    });
+
+    it("WhoAttestLog is working", async function() {
+      assert.strictEqual(WhoAttestLog.encryptedBytes, encryptedBytes);
+      assert.strictEqual(WhoAttestLog.version, version);
+      assert.strictEqual(WhoAttestLog.itemAddress, datastoreRelation.address);
+      assert.strictEqual(WhoAttestLog.topic, initTopic2);
+      assert.strictEqual(WhoAttestLog.attestor, hara);
+    });
+
+    it("AttestLog is working", async function() {
+      assert.strictEqual(AttestLog.encryptedBytes, encryptedBytes);
+      assert.strictEqual(AttestLog.version, version);
+      assert.strictEqual(AttestLog.itemAddress, datastoreRelation.address);
+      assert.strictEqual(AttestLog.topic, initTopic2);
+      assert.strictEqual(AttestLog.attestor, hara);
+    });
+  });
+});


### PR DESCRIPTION
## New Contract
- ens/ENS: Ethereum name services abstraction.
- ens/HNS: Hara Name Services Registry contract.
- ens/HaraRegistrar: Registrar to regist new node by staking with hart.
- ens/OwnerRegistrar: Registrar to regist new node by owner only.
- ens/HaraResolver: Contract to keep all resolvers of nodes.
- DataFactoryProvider: Contract to add data store relation version and it's value.
- DataProviderNull: Data provider that return null URI.
- DataProviderProxy: A proxy contract for curren tactive data provider.
- DataProviderRelation: Data provider that keep relation of data store.

 ## Contract Changes
- [IDataProvider ] Changes `_priceId` parameter to `version`.
- [Attest Contract] Implement EIP-780.
- [Data Store] Changes `signature` storage from `bytes` to `mapping(bytes32=>bytes)`.
- [Data Store] Add `editor` to allow DataFactoryProvider add new version.
